### PR TITLE
Fix infinite login loop caused by Claude.ai desktop app redirects

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,58 @@
+name: Build Windows (Setup + Portable)
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        node-version: [18]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Electron app (Setup + Portable)
+        run: npm run build:win
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Setup installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: Claude-Usage-Widget-Setup
+          path: dist/*Setup*.exe
+          if-no-files-found: error
+
+      - name: Upload Portable executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: Claude-Usage-Widget-Portable
+          path: dist/*portable*.exe
+          if-no-files-found: error
+
+      - name: Upload to Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*Setup*.exe
+            dist/*portable*.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ npm install
 - No data is sent to any third-party servers
 - The widget only communicates with Claude.ai official API
 - Session cookies are stored using Electron's secure storage
+- **Logout** completely removes the session key from encrypted storage, clears all Claude.ai cookies, and wipes Electron session storage (localStorage, sessionStorage, cacheStorage) so nothing lingers on shared machines
+
+### Session Key Storage Details
+
+The `sessionKey` (a bearer token for Claude.ai) is stored in two places:
+
+| Location | Purpose | Cleared on logout? |
+|---|---|---|
+| `%APPDATA%/claude-usage-widget/config.json` (encrypted via `electron-store`) | Persists credentials between app restarts | Yes |
+| Electron in-memory session cookie (`.claude.ai` domain, `secure`, `httpOnly`) | Used by hidden BrowserWindow for API requests | Yes |
+
+The encryption key is embedded in the application. This protects against casual file inspection but not against a determined attacker with access to the source code. For shared machines, always log out when finished.
 
 ## Technical Details
 
@@ -150,6 +162,17 @@ https://claude.ai/api/organizations/{org_id}/usage
 **Storage Location:**
 ```
 %APPDATA%/claude-usage-widget/config.json (encrypted)
+```
+
+**Debug Mode:**
+
+To enable verbose logging, run with the `--debug` flag or set the `DEBUG_LOG=1` environment variable:
+```bash
+# Via flag
+electron . --debug
+
+# Via env var
+DEBUG_LOG=1 npm start
 ```
 
 ## Roadmap

--- a/package.json
+++ b/package.json
@@ -18,13 +18,12 @@
   "author": "Your Name",
   "license": "MIT",
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "electron": "^28.0.0",
-    "electron-builder": "^24.9.1",
-    "cross-env": "^7.0.3"
+    "electron-builder": "^24.9.1"
   },
   "dependencies": {
-    "electron-store": "^8.1.0",
-    "axios": "^1.6.2"
+    "electron-store": "^8.1.0"
   },
   "build": {
     "appId": "com.claudeusage.widget",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   ],
   "author": "Your Name",
   "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  },
   "devDependencies": {
     "cross-env": "^7.0.3",
     "electron": "^28.0.0",
@@ -30,9 +34,13 @@
     "productName": "Claude Usage Widget",
     "win": {
       "target": [
-        "nsis"
+        "nsis",
+        "portable"
       ],
       "icon": "assets/icon.ico"
+    },
+    "portable": {
+      "artifactName": "${productName}-${version}-portable.${ext}"
     },
     "nsis": {
       "oneClick": false,

--- a/preload.js
+++ b/preload.js
@@ -1,37 +1,28 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-// Expose protected methods that allow the renderer process to use
-// the ipcRenderer without exposing the entire object
 contextBridge.exposeInMainWorld('electronAPI', {
   // Credentials management
   getCredentials: () => ipcRenderer.invoke('get-credentials'),
   saveCredentials: (credentials) => ipcRenderer.invoke('save-credentials', credentials),
   deleteCredentials: () => ipcRenderer.invoke('delete-credentials'),
+  validateSessionKey: (sessionKey) => ipcRenderer.invoke('validate-session-key', sessionKey),
+  detectSessionKey: () => ipcRenderer.invoke('detect-session-key'),
 
   // Window controls
   minimizeWindow: () => ipcRenderer.send('minimize-window'),
   closeWindow: () => ipcRenderer.send('close-window'),
-  openLogin: () => ipcRenderer.send('open-login'),
+  resizeWindow: (height) => ipcRenderer.send('resize-window', height),
 
   // Window position
   getWindowPosition: () => ipcRenderer.invoke('get-window-position'),
   setWindowPosition: (position) => ipcRenderer.invoke('set-window-position', position),
 
   // Event listeners
-  onLoginSuccess: (callback) => {
-    ipcRenderer.on('login-success', (event, data) => callback(data));
-  },
   onRefreshUsage: (callback) => {
     ipcRenderer.on('refresh-usage', () => callback());
   },
   onSessionExpired: (callback) => {
     ipcRenderer.on('session-expired', () => callback());
-  },
-  onSilentLoginStarted: (callback) => {
-    ipcRenderer.on('silent-login-started', () => callback());
-  },
-  onSilentLoginFailed: (callback) => {
-    ipcRenderer.on('silent-login-failed', () => callback());
   },
 
   // API

--- a/src/fetch-via-window.js
+++ b/src/fetch-via-window.js
@@ -1,0 +1,85 @@
+/**
+ * fetch-via-window.js
+ *
+ * Fetches JSON from a URL using a hidden BrowserWindow.
+ *
+ * Why this exists:
+ * Claude.ai uses Cloudflare protection and detects Electron's default
+ * request headers, blocking standard Node.js fetch/http requests.
+ * By loading the URL in a hidden BrowserWindow with a spoofed Chrome
+ * User-Agent, we ride on the browser session cookies and bypass
+ * Cloudflare's bot detection. This is the simplest reliable approach
+ * after the previous cookie-database-reading strategy proved too
+ * fragile and OS-specific.
+ */
+const { BrowserWindow } = require('electron');
+
+/**
+ * Known error signatures returned when Claude.ai blocks or changes behaviour.
+ * If the extracted body matches one of these patterns we throw a specific error
+ * so callers can react (e.g. prompt re-login).
+ */
+const BLOCKED_SIGNATURES = [
+  { pattern: 'Just a moment', error: 'CloudflareBlocked' },
+  { pattern: 'Enable JavaScript and cookies to continue', error: 'CloudflareChallenge' },
+  { pattern: '<html', error: 'UnexpectedHTML' },
+];
+
+function fetchViaWindow(url, { timeoutMs = 30000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const win = new BrowserWindow({
+      width: 800,
+      height: 600,
+      show: false,
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true
+      }
+    });
+
+    const timeout = setTimeout(() => {
+      win.close();
+      reject(new Error('Request timeout'));
+    }, timeoutMs);
+
+    win.webContents.on('did-finish-load', async () => {
+      try {
+        const bodyText = await win.webContents.executeJavaScript(
+          'document.body.innerText || document.body.textContent'
+        );
+        clearTimeout(timeout);
+        win.close();
+
+        // Detect known block/failure signatures before attempting JSON parse.
+        // This provides explicit errors when Claude.ai modifies their API or CSP.
+        for (const sig of BLOCKED_SIGNATURES) {
+          if (bodyText.includes(sig.pattern)) {
+            reject(new Error(`${sig.error}: ${bodyText.substring(0, 200)}`));
+            return;
+          }
+        }
+
+        try {
+          const data = JSON.parse(bodyText);
+          resolve(data);
+        } catch (parseErr) {
+          reject(new Error('InvalidJSON: ' + bodyText.substring(0, 200)));
+        }
+      } catch (err) {
+        clearTimeout(timeout);
+        win.close();
+        reject(err);
+      }
+    });
+
+    win.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
+      clearTimeout(timeout);
+      win.close();
+      reject(new Error(`LoadFailed: ${errorCode} ${errorDescription}`));
+    });
+
+    win.loadURL(url);
+  });
+}
+
+module.exports = { fetchViaWindow };

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -8,6 +8,13 @@ const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const WIDGET_HEIGHT_COLLAPSED = 140;
 const WIDGET_ROW_HEIGHT = 30;
 
+// Debug logging — only shows in DevTools (development mode).
+// Regular users won't see verbose logs in production.
+const DEBUG = (new URLSearchParams(window.location.search)).has('debug');
+function debugLog(...args) {
+  if (DEBUG) console.log('[Debug]', ...args);
+}
+
 // DOM elements
 const elements = {
     loadingContainer: document.getElementById('loadingContainer'),
@@ -96,7 +103,7 @@ function setupEventListeners() {
     });
 
     elements.refreshBtn.addEventListener('click', async () => {
-        console.log('Refresh button clicked');
+        debugLog('Refresh button clicked');
         elements.refreshBtn.classList.add('spinning');
         await fetchUsageData();
         elements.refreshBtn.classList.remove('spinning');
@@ -145,7 +152,7 @@ function setupEventListeners() {
 
     // Listen for session expiration events (403 errors)
     window.electronAPI.onSessionExpired(() => {
-        console.log('Session expired event received');
+        debugLog('Session expired event received');
         credentials = { sessionKey: null, organizationId: null };
         showLoginRequired();
     });
@@ -223,18 +230,18 @@ async function handleAutoDetect() {
 
 // Fetch usage data from Claude API
 async function fetchUsageData() {
-    console.log('fetchUsageData called', { credentials });
+    debugLog('fetchUsageData called');
 
     if (!credentials.sessionKey || !credentials.organizationId) {
-        console.log('Missing credentials, showing login');
+        debugLog('Missing credentials, showing login');
         showLoginRequired();
         return;
     }
 
     try {
-        console.log('Calling electronAPI.fetchUsageData...');
+        debugLog('Calling electronAPI.fetchUsageData...');
         const data = await window.electronAPI.fetchUsageData();
-        console.log('Received usage data:', data);
+        debugLog('Received usage data:', data);
         updateUI(data);
     } catch (error) {
         console.error('Error fetching usage data:', error);
@@ -242,7 +249,7 @@ async function fetchUsageData() {
             credentials = { sessionKey: null, organizationId: null };
             showLoginRequired();
         } else {
-            console.error('Failed to fetch usage data');
+            debugLog('Failed to fetch usage data');
         }
     }
 }
@@ -374,7 +381,7 @@ function refreshTimers() {
         const sessionDiff = new Date(sessionResetsAt) - new Date();
         if (sessionDiff <= 0 && !sessionResetTriggered) {
             sessionResetTriggered = true;
-            console.log('Session timer expired, triggering refresh...');
+            debugLog('Session timer expired, triggering refresh...');
             // Wait a few seconds for the server to update, then refresh
             setTimeout(() => {
                 fetchUsageData();
@@ -406,7 +413,7 @@ function refreshTimers() {
         const weeklyDiff = new Date(weeklyResetsAt) - new Date();
         if (weeklyDiff <= 0 && !weeklyResetTriggered) {
             weeklyResetTriggered = true;
-            console.log('Weekly timer expired, triggering refresh...');
+            debugLog('Weekly timer expired, triggering refresh...');
             setTimeout(() => {
                 fetchUsageData();
             }, 3000);

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -3,16 +3,27 @@ let credentials = null;
 let updateInterval = null;
 let countdownInterval = null;
 let latestUsageData = null;
+let isExpanded = false;
 const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
+const WIDGET_HEIGHT_COLLAPSED = 140;
+const WIDGET_ROW_HEIGHT = 30;
 
 // DOM elements
 const elements = {
     loadingContainer: document.getElementById('loadingContainer'),
     loginContainer: document.getElementById('loginContainer'),
     noUsageContainer: document.getElementById('noUsageContainer'),
-    autoLoginContainer: document.getElementById('autoLoginContainer'),
     mainContent: document.getElementById('mainContent'),
-    loginBtn: document.getElementById('loginBtn'),
+    loginStep1: document.getElementById('loginStep1'),
+    loginStep2: document.getElementById('loginStep2'),
+    autoDetectBtn: document.getElementById('autoDetectBtn'),
+    autoDetectError: document.getElementById('autoDetectError'),
+    openBrowserLink: document.getElementById('openBrowserLink'),
+    nextStepBtn: document.getElementById('nextStepBtn'),
+    backStepBtn: document.getElementById('backStepBtn'),
+    sessionKeyInput: document.getElementById('sessionKeyInput'),
+    connectBtn: document.getElementById('connectBtn'),
+    sessionKeyError: document.getElementById('sessionKeyError'),
     refreshBtn: document.getElementById('refreshBtn'),
     minimizeBtn: document.getElementById('minimizeBtn'),
     closeBtn: document.getElementById('closeBtn'),
@@ -26,6 +37,11 @@ const elements = {
     weeklyProgress: document.getElementById('weeklyProgress'),
     weeklyTimer: document.getElementById('weeklyTimer'),
     weeklyTimeText: document.getElementById('weeklyTimeText'),
+
+    expandToggle: document.getElementById('expandToggle'),
+    expandArrow: document.getElementById('expandArrow'),
+    expandSection: document.getElementById('expandSection'),
+    extraRows: document.getElementById('extraRows'),
 
     settingsBtn: document.getElementById('settingsBtn'),
     settingsOverlay: document.getElementById('settingsOverlay'),
@@ -50,8 +66,33 @@ async function init() {
 
 // Event Listeners
 function setupEventListeners() {
-    elements.loginBtn.addEventListener('click', () => {
-        window.electronAPI.openLogin();
+    // Step 1: Login via BrowserWindow
+    elements.autoDetectBtn.addEventListener('click', handleAutoDetect);
+
+    // Step navigation
+    elements.nextStepBtn.addEventListener('click', () => {
+        elements.loginStep1.style.display = 'none';
+        elements.loginStep2.style.display = 'block';
+        elements.sessionKeyInput.focus();
+    });
+
+    elements.backStepBtn.addEventListener('click', () => {
+        elements.loginStep2.style.display = 'none';
+        elements.loginStep1.style.display = 'flex';
+        elements.sessionKeyError.textContent = '';
+    });
+
+    // Open browser link in step 2
+    elements.openBrowserLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        window.electronAPI.openExternal('https://claude.ai');
+    });
+
+    // Step 2: Manual sessionKey connect
+    elements.connectBtn.addEventListener('click', handleConnect);
+    elements.sessionKeyInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') handleConnect();
+        elements.sessionKeyError.textContent = '';
     });
 
     elements.refreshBtn.addEventListener('click', async () => {
@@ -66,7 +107,15 @@ function setupEventListeners() {
     });
 
     elements.closeBtn.addEventListener('click', () => {
-        window.electronAPI.closeWindow(); // Exit application completely
+        window.electronAPI.closeWindow();
+    });
+
+    // Expand/collapse toggle
+    elements.expandToggle.addEventListener('click', () => {
+        isExpanded = !isExpanded;
+        elements.expandArrow.classList.toggle('expanded', isExpanded);
+        elements.expandSection.style.display = isExpanded ? 'block' : 'none';
+        resizeWidget();
     });
 
     // Settings calls
@@ -80,24 +129,13 @@ function setupEventListeners() {
 
     elements.logoutBtn.addEventListener('click', async () => {
         await window.electronAPI.deleteCredentials();
+        credentials = { sessionKey: null, organizationId: null };
         elements.settingsOverlay.style.display = 'none';
         showLoginRequired();
-        window.electronAPI.openLogin();
     });
 
     elements.coffeeBtn.addEventListener('click', () => {
         window.electronAPI.openExternal('https://paypal.me/SlavomirDurej?country.x=GB&locale.x=en_GB');
-    });
-
-    // Listen for login success
-    window.electronAPI.onLoginSuccess(async (data) => {
-        console.log('Renderer received login-success event', data);
-        credentials = data;
-        await window.electronAPI.saveCredentials(data);
-        console.log('Credentials saved, showing main content');
-        showMainContent();
-        await fetchUsageData();
-        startAutoUpdate();
     });
 
     // Listen for refresh requests from tray
@@ -105,24 +143,82 @@ function setupEventListeners() {
         await fetchUsageData();
     });
 
-    // Listen for session expiration events (403 errors) - only used as fallback
+    // Listen for session expiration events (403 errors)
     window.electronAPI.onSessionExpired(() => {
         console.log('Session expired event received');
         credentials = { sessionKey: null, organizationId: null };
         showLoginRequired();
     });
+}
 
-    // Listen for silent login attempts
-    window.electronAPI.onSilentLoginStarted(() => {
-        console.log('Silent login started...');
-        showAutoLoginAttempt();
-    });
+// Handle manual sessionKey connect
+async function handleConnect() {
+    const sessionKey = elements.sessionKeyInput.value.trim();
+    if (!sessionKey) {
+        elements.sessionKeyError.textContent = 'Please paste your session key';
+        return;
+    }
 
-    // Listen for silent login failures (falls back to visible login)
-    window.electronAPI.onSilentLoginFailed(() => {
-        console.log('Silent login failed, manual login required');
-        showLoginRequired();
-    });
+    elements.connectBtn.disabled = true;
+    elements.connectBtn.textContent = '...';
+    elements.sessionKeyError.textContent = '';
+
+    try {
+        const result = await window.electronAPI.validateSessionKey(sessionKey);
+        if (result.success) {
+            credentials = { sessionKey, organizationId: result.organizationId };
+            await window.electronAPI.saveCredentials(credentials);
+            elements.sessionKeyInput.value = '';
+            showMainContent();
+            await fetchUsageData();
+            startAutoUpdate();
+        } else {
+            elements.sessionKeyError.textContent = result.error || 'Invalid session key';
+        }
+    } catch (error) {
+        elements.sessionKeyError.textContent = 'Connection failed. Check your key.';
+    } finally {
+        elements.connectBtn.disabled = false;
+        elements.connectBtn.textContent = 'Connect';
+    }
+}
+
+// Handle auto-detect from browser cookies
+async function handleAutoDetect() {
+    elements.autoDetectBtn.disabled = true;
+    elements.autoDetectBtn.textContent = 'Waiting...';
+    elements.autoDetectError.textContent = '';
+
+    try {
+        const result = await window.electronAPI.detectSessionKey();
+        if (!result.success) {
+            elements.autoDetectError.textContent = result.error || 'Login failed';
+            return;
+        }
+
+        // Got sessionKey from login, now validate it
+        elements.autoDetectBtn.textContent = 'Validating...';
+        const validation = await window.electronAPI.validateSessionKey(result.sessionKey);
+
+        if (validation.success) {
+            credentials = {
+                sessionKey: result.sessionKey,
+                organizationId: validation.organizationId
+            };
+            await window.electronAPI.saveCredentials(credentials);
+            showMainContent();
+            await fetchUsageData();
+            startAutoUpdate();
+        } else {
+            elements.autoDetectError.textContent =
+                'Session invalid. Try again or use Manual →';
+        }
+    } catch (error) {
+        elements.autoDetectError.textContent = error.message || 'Login failed';
+    } finally {
+        elements.autoDetectBtn.disabled = false;
+        elements.autoDetectBtn.textContent = 'Log in';
+    }
 }
 
 // Fetch usage data from Claude API
@@ -143,12 +239,10 @@ async function fetchUsageData() {
     } catch (error) {
         console.error('Error fetching usage data:', error);
         if (error.message.includes('SessionExpired') || error.message.includes('Unauthorized')) {
-            // Session expired - silent login attempt is in progress
-            // Show auto-login UI while waiting
             credentials = { sessionKey: null, organizationId: null };
-            showAutoLoginAttempt();
+            showLoginRequired();
         } else {
-            showError('Failed to fetch usage data');
+            console.error('Failed to fetch usage data');
         }
     }
 }
@@ -165,17 +259,102 @@ function hasNoUsage(data) {
 }
 
 // Update UI with usage data
+// Extra row label mapping for API fields
+const EXTRA_ROW_CONFIG = {
+    seven_day_sonnet: { label: 'Sonnet (7d)', color: 'weekly' },
+    seven_day_opus: { label: 'Opus (7d)', color: 'opus' },
+    seven_day_cowork: { label: 'Cowork (7d)', color: 'weekly' },
+    seven_day_oauth_apps: { label: 'OAuth Apps (7d)', color: 'weekly' },
+    extra_usage: { label: 'Extra Usage', color: 'extra' },
+};
+
+function buildExtraRows(data) {
+    elements.extraRows.innerHTML = '';
+    let count = 0;
+
+    for (const [key, config] of Object.entries(EXTRA_ROW_CONFIG)) {
+        const value = data[key];
+        if (!value || value.utilization === undefined) continue;
+
+        const utilization = value.utilization || 0;
+        const resetsAt = value.resets_at;
+        const colorClass = config.color;
+
+        const row = document.createElement('div');
+        row.className = 'usage-section';
+        row.innerHTML = `
+            <span class="usage-label">${config.label}</span>
+            <div class="progress-bar">
+                <div class="progress-fill ${colorClass}" style="width: ${Math.min(utilization, 100)}%"></div>
+            </div>
+            <span class="usage-percentage">${Math.round(utilization)}%</span>
+            <div class="timer-container">
+                <div class="timer-text" data-resets="${resetsAt || ''}" data-total="${key.includes('seven_day') ? 7 * 24 * 60 : 5 * 60}">--:--</div>
+                <svg class="mini-timer" width="24" height="24" viewBox="0 0 24 24">
+                    <circle class="timer-bg" cx="12" cy="12" r="10" />
+                    <circle class="timer-progress ${colorClass}" cx="12" cy="12" r="10"
+                        style="stroke-dasharray: 63; stroke-dashoffset: 63" />
+                </svg>
+            </div>
+        `;
+
+        // Apply warning/danger classes
+        const progressEl = row.querySelector('.progress-fill');
+        if (utilization >= 90) progressEl.classList.add('danger');
+        else if (utilization >= 75) progressEl.classList.add('warning');
+
+        elements.extraRows.appendChild(row);
+        count++;
+    }
+
+    // Hide toggle if no extra rows
+    elements.expandToggle.style.display = count > 0 ? 'flex' : 'none';
+    if (count === 0 && isExpanded) {
+        isExpanded = false;
+        elements.expandArrow.classList.remove('expanded');
+        elements.expandSection.style.display = 'none';
+    }
+
+    return count;
+}
+
+function refreshExtraTimers() {
+    const timerTexts = elements.extraRows.querySelectorAll('.timer-text');
+    const timerCircles = elements.extraRows.querySelectorAll('.timer-progress');
+
+    timerTexts.forEach((textEl, i) => {
+        const resetsAt = textEl.dataset.resets;
+        const totalMinutes = parseInt(textEl.dataset.total);
+        const circleEl = timerCircles[i];
+        if (resetsAt && circleEl) {
+            updateTimer(circleEl, textEl, resetsAt, totalMinutes);
+        }
+    });
+}
+
+function resizeWidget() {
+    const extraCount = elements.extraRows.children.length;
+    if (isExpanded && extraCount > 0) {
+        const expandedHeight = WIDGET_HEIGHT_COLLAPSED + 12 + (extraCount * WIDGET_ROW_HEIGHT);
+        window.electronAPI.resizeWindow(expandedHeight);
+    } else {
+        window.electronAPI.resizeWindow(WIDGET_HEIGHT_COLLAPSED);
+    }
+}
+
 function updateUI(data) {
     latestUsageData = data;
 
-    // Check if there's no usage data
     if (hasNoUsage(data)) {
         showNoUsage();
         return;
     }
 
     showMainContent();
+    buildExtraRows(data);
     refreshTimers();
+    if (isExpanded) refreshExtraTimers();
+    resizeWidget();
     startCountdown();
 }
 
@@ -255,6 +434,7 @@ function startCountdown() {
     if (countdownInterval) clearInterval(countdownInterval);
     countdownInterval = setInterval(() => {
         refreshTimers();
+        if (isExpanded) refreshExtraTimers();
     }, 1000);
 }
 
@@ -334,20 +514,16 @@ function updateTimer(timerElement, textElement, resetsAt, totalMinutes) {
 }
 
 // UI State Management
-function showLoading() {
-    elements.loadingContainer.style.display = 'block';
-    elements.loginContainer.style.display = 'none';
-    elements.noUsageContainer.style.display = 'none';
-    elements.autoLoginContainer.style.display = 'none';
-    elements.mainContent.style.display = 'none';
-}
-
 function showLoginRequired() {
     elements.loadingContainer.style.display = 'none';
-    elements.loginContainer.style.display = 'flex'; // Use flex to preserve centering
+    elements.loginContainer.style.display = 'flex';
     elements.noUsageContainer.style.display = 'none';
-    elements.autoLoginContainer.style.display = 'none';
     elements.mainContent.style.display = 'none';
+    // Reset to step 1
+    elements.loginStep1.style.display = 'flex';
+    elements.loginStep2.style.display = 'none';
+    elements.sessionKeyError.textContent = '';
+    elements.sessionKeyInput.value = '';
     stopAutoUpdate();
 }
 
@@ -355,30 +531,14 @@ function showNoUsage() {
     elements.loadingContainer.style.display = 'none';
     elements.loginContainer.style.display = 'none';
     elements.noUsageContainer.style.display = 'flex';
-    elements.autoLoginContainer.style.display = 'none';
     elements.mainContent.style.display = 'none';
-}
-
-function showAutoLoginAttempt() {
-    elements.loadingContainer.style.display = 'none';
-    elements.loginContainer.style.display = 'none';
-    elements.noUsageContainer.style.display = 'none';
-    elements.autoLoginContainer.style.display = 'flex';
-    elements.mainContent.style.display = 'none';
-    stopAutoUpdate();
 }
 
 function showMainContent() {
     elements.loadingContainer.style.display = 'none';
     elements.loginContainer.style.display = 'none';
     elements.noUsageContainer.style.display = 'none';
-    elements.autoLoginContainer.style.display = 'none';
     elements.mainContent.style.display = 'block';
-}
-
-function showError(message) {
-    // TODO: Implement error notification
-    console.error(message);
 }
 
 // Auto-update management

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -40,19 +40,45 @@
                 <p>Loading usage data...</p>
             </div>
 
-            <!-- Login Required State -->
+            <!-- Login -->
             <div class="login-container" id="loginContainer" style="display: none;">
                 <div class="login-content">
-                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
-                        <polyline points="10 17 15 12 10 7" />
-                        <line x1="15" y1="12" x2="3" y2="12" />
-                    </svg>
-                    <div class="login-text-group">
-                        <h3>Login Required</h3>
-                        <p>Log in to view usage stats</p>
+                    <div class="login-step1" id="loginStep1">
+                        <div class="step-icon">
+                            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+                                <polyline points="10 17 15 12 10 7" />
+                                <line x1="15" y1="12" x2="3" y2="12" />
+                            </svg>
+                        </div>
+                        <div class="step-text">
+                            <h3>Connect to Claude.ai</h3>
+                            <p>Log in to your Claude account</p>
+                            <p class="step-error" id="autoDetectError"></p>
+                        </div>
+                        <button class="auto-detect-btn" id="autoDetectBtn">Log in</button>
+                        <button class="next-step-btn" id="nextStepBtn">Manual →</button>
                     </div>
-                    <button class="login-btn" id="loginBtn">Log In</button>
+
+                    <div class="login-step2" id="loginStep2" style="display: none;">
+                        <div class="session-key-form">
+                            <div class="session-key-header">
+                                <h3>Paste your Session Key</h3>
+                                <p>
+                                    <a href="#" id="openBrowserLink" class="open-browser-link">Open claude.ai</a>
+                                    → <code>F12</code> → Application → Cookies → <code>sessionKey</code>
+                                </p>
+                            </div>
+                            <div class="session-key-input-row">
+                                <input type="password" id="sessionKeyInput" placeholder="sk-ant-sid01-..." spellcheck="false" autocomplete="off">
+                                <button class="connect-btn" id="connectBtn">Connect</button>
+                            </div>
+                            <div class="session-key-footer">
+                                <p class="session-key-error" id="sessionKeyError"></p>
+                                <button class="back-step-btn" id="backStepBtn">← Back</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -65,17 +91,6 @@
                     <div class="no-usage-text-group">
                         <h3>No Usage Yet</h3>
                         <p>Start chatting with Claude to see your usage stats</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Auto-Login Attempt State -->
-            <div class="auto-login-container" id="autoLoginContainer" style="display: none;">
-                <div class="auto-login-content">
-                    <div class="spinner"></div>
-                    <div class="auto-login-text-group">
-                        <h3>Trying to auto-login...</h3>
-                        <p>Please wait while we reconnect</p>
                     </div>
                 </div>
             </div>
@@ -116,8 +131,18 @@
                     </div>
                 </div>
 
-                <!-- Hidden Footer element (removed) -->
-                <span id="lastUpdate" style="display: none;"></span>
+                <!-- Expand Toggle -->
+                <div class="expand-toggle" id="expandToggle">
+                    <svg class="expand-arrow" id="expandArrow" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="6 9 12 15 18 9" />
+                    </svg>
+                </div>
+
+                <!-- Expandable Details -->
+                <div class="expand-section" id="expandSection" style="display: none;">
+                    <div id="extraRows"></div>
+                </div>
+
             </div>
 
             <!-- Settings Overlay -->

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -54,6 +54,7 @@
                         <div class="step-text">
                             <h3>Connect to Claude.ai</h3>
                             <p>Log in to your Claude account</p>
+                            <p class="step-hint">If auto-login doesn't work, use Manual to paste your session key — Claude.ai may block embedded browsers.</p>
                             <p class="step-error" id="autoDetectError"></p>
                         </div>
                         <button class="auto-detect-btn" id="autoDetectBtn">Log in</button>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -680,38 +680,6 @@ body {
     white-space: nowrap;
 }
 
-.debug-btn {
-    background: rgba(255, 255, 255, 0.05);
-    color: #707070;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    padding: 6px 12px;
-    border-radius: 6px;
-    font-size: 10px;
-    cursor: pointer;
-    transition: all 0.2s;
-    width: 100%;
-}
-
-.debug-btn:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: #a0a0a0;
-}
-
-.debug-output {
-    background: rgba(0, 0, 0, 0.4);
-    color: #8b5cf6;
-    font-size: 9px;
-    font-family: monospace;
-    padding: 8px;
-    border-radius: 6px;
-    max-height: 200px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
-    text-align: left;
-    user-select: all;
-}
-
 .coffee-btn {
     background: linear-gradient(135deg, #FFD700 0%, #FFA500 100%);
     color: #1a1a1a;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -125,57 +125,59 @@ body {
 .login-container {
     padding: 0 16px;
     flex: 1;
-    /* Fill remaining vertical space */
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
 .login-content {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    text-align: left;
     width: 100%;
-    justify-content: space-between;
 }
 
-.login-content svg {
+/* Step 1: Auto-detect */
+.login-step1 {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    width: 100%;
+}
+
+.step-icon svg {
     color: #8b5cf6;
-    margin-bottom: 0;
-    width: 32px;
-    height: 32px;
     flex-shrink: 0;
 }
 
-.login-text-group {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    margin-right: auto;
-    /* Push button to right if space permits */
-    padding-left: 12px;
+.step-text {
+    flex: 1;
 }
 
-.login-content h3 {
+.step-text h3 {
     color: #e0e0e0;
     font-size: 14px;
     margin-bottom: 2px;
 }
 
-.login-content p {
+.step-text p {
     color: #a0a0a0;
     font-size: 11px;
-    margin-bottom: 0;
+    margin: 0;
 }
 
-.login-btn {
+.step-error {
+    color: #ef4444;
+    font-size: 9px;
+    margin-top: 2px;
+    min-height: 0;
+    word-break: break-word;
+}
+
+.auto-detect-btn {
     background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
     color: white;
     border: none;
-    padding: 8px 16px;
+    padding: 8px 14px;
     border-radius: 6px;
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -183,9 +185,157 @@ body {
     flex-shrink: 0;
 }
 
-.login-btn:hover {
+.auto-detect-btn:hover {
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+}
+
+.auto-detect-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.open-browser-link {
+    color: #a78bfa;
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.open-browser-link:hover {
+    color: #c4b5fd;
+    text-decoration: underline;
+}
+
+.next-step-btn {
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #a0a0a0;
+    padding: 8px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.next-step-btn:hover {
+    border-color: rgba(255, 255, 255, 0.3);
+    color: #e0e0e0;
+}
+
+/* Step 2: Paste Session Key */
+.session-key-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+}
+
+.session-key-header h3 {
+    color: #e0e0e0;
+    font-size: 13px;
+    margin-bottom: 3px;
+}
+
+.session-key-header p {
+    color: #707070;
+    font-size: 10px;
+    margin-bottom: 0;
+}
+
+.session-key-header code {
+    background: rgba(139, 92, 246, 0.2);
+    color: #a78bfa;
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+}
+
+.session-key-input-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.session-key-input-row input {
+    flex: 1;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #e0e0e0;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-family: monospace;
+    transition: border-color 0.2s;
+}
+
+.session-key-input-row input:focus {
+    border-color: #8b5cf6;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.session-key-input-row input::placeholder {
+    color: #505050;
+}
+
+.connect-btn {
+    background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+    color: white;
+    border: none;
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.connect-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+}
+
+.connect-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.session-key-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.session-key-error {
+    color: #ef4444;
+    font-size: 9px;
+    min-height: 14px;
+    max-height: 40px;
+    overflow-y: auto;
+    margin: 0;
+    flex: 1;
+    word-break: break-all;
+    font-family: monospace;
+}
+
+.back-step-btn {
+    background: none;
+    border: none;
+    color: #707070;
+    font-size: 10px;
+    cursor: pointer;
+    padding: 2px 4px;
+    transition: color 0.2s;
+    flex-shrink: 0;
+}
+
+.back-step-btn:hover {
+    color: #a0a0a0;
 }
 
 /* No Usage State */
@@ -274,7 +424,45 @@ body {
 
 /* Main Content */
 .content {
-    padding: 20px;
+    padding: 16px 20px;
+}
+
+/* Expand Toggle */
+.expand-toggle {
+    display: flex;
+    justify-content: center;
+    padding: 2px 0 0;
+    cursor: pointer;
+}
+
+.expand-arrow {
+    color: #505050;
+    transition: all 0.2s ease;
+}
+
+.expand-toggle:hover .expand-arrow {
+    color: #a0a0a0;
+}
+
+.expand-arrow.expanded {
+    transform: rotate(180deg);
+}
+
+/* Expandable Section */
+.expand-section {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    margin-top: 6px;
+    padding-top: 6px;
+}
+
+.expand-section .usage-section {
+    height: 28px;
+    margin-bottom: 0;
+}
+
+.expand-section .usage-label {
+    font-size: 10px;
+    color: #808080;
 }
 
 .usage-section {
@@ -452,6 +640,38 @@ body {
     line-height: 1.2;
     margin-bottom: 12px;
     white-space: nowrap;
+}
+
+.debug-btn {
+    background: rgba(255, 255, 255, 0.05);
+    color: #707070;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 10px;
+    cursor: pointer;
+    transition: all 0.2s;
+    width: 100%;
+}
+
+.debug-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #a0a0a0;
+}
+
+.debug-output {
+    background: rgba(0, 0, 0, 0.4);
+    color: #8b5cf6;
+    font-size: 9px;
+    font-family: monospace;
+    padding: 8px;
+    border-radius: 6px;
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    text-align: left;
+    user-select: all;
 }
 
 .coffee-btn {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -163,6 +163,13 @@ body {
     margin: 0;
 }
 
+.step-hint {
+    color: #707070;
+    font-size: 9px;
+    margin-top: 2px;
+    font-style: italic;
+}
+
 .step-error {
     color: #ef4444;
     font-size: 9px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -548,6 +548,16 @@ body {
     box-shadow: 0 0 10px rgba(59, 130, 246, 0.3);
 }
 
+.progress-fill.extra {
+    background: linear-gradient(90deg, #10b981 0%, #34d399 100%);
+    box-shadow: 0 0 10px rgba(16, 185, 129, 0.3);
+}
+
+.progress-fill.opus {
+    background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%);
+    box-shadow: 0 0 10px rgba(245, 158, 11, 0.3);
+}
+
 
 /* Timer Container */
 .timer-container {
@@ -582,12 +592,33 @@ body {
     stroke: #3b82f6;
 }
 
+.timer-progress.extra {
+    stroke: #10b981;
+}
+
+.timer-progress.opus {
+    stroke: #f59e0b;
+}
+
 .timer-text {
     color: #e0e0e0;
     font-size: 13px;
     font-weight: 500;
     font-variant-numeric: tabular-nums;
     font-family: inherit;
+}
+
+.timer-text.extra-spending,
+.usage-percentage.extra-spending {
+    font-size: 10px;
+    color: #10b981;
+    opacity: 0.8;
+}
+
+.timer-text.extra-balance {
+    font-size: 10px;
+    color: #34d399;
+    font-weight: 600;
 }
 
 /* Settings Overlay */


### PR DESCRIPTION
## Summary

This PR fixes the broken login flow and replaces the HTTP request layer to work around Cloudflare blocking.

### Problems

1. **Login white screen**: Claude.ai detects Electron's embedded browser and blocks rendering, causing infinite login loops
2. **API requests blocked by Cloudflare**: `axios` HTTP requests get intercepted by Cloudflare's "Just a moment..." challenge page, returning no data
3. **Session expiration not handled gracefully**: When the sessionKey expires, the widget had no clean recovery path

### Changes

**API layer: axios → hidden BrowserWindow**
- Replaced all `axios` HTTP calls with `fetchViaWindow()`, which creates a hidden `BrowserWindow`, navigates to the API URL, and extracts the JSON response via `executeJavaScript`
- This uses a real browser context that passes Cloudflare checks automatically
- Set session-level User-Agent to Chrome to prevent Electron detection

**Login flow: two options**
- **Primary**: Opens a visible `BrowserWindow` to `claude.ai/login` where the user logs in directly. Electron's session captures the `sessionKey` cookie automatically via `cookies.on('changed')`
- **Manual fallback**: User can paste a `sessionKey` directly from browser DevTools (F12 → Application → Cookies)
- Removed the old silent login / auto-login mechanism entirely

**Expandable widget**
- Added expand/collapse toggle to show per-model usage breakdown (Sonnet, Opus, Cowork, OAuth Apps, Extra Usage)
- Widget dynamically resizes based on expanded state

**Cleanup**
- Removed `axios` dependency
- Removed unused auto-login UI state and debug features
- Simplified settings overlay (removed raw API response viewer)

--
If you find my work helpful, fuel the next commit with a coffee ☕
  <a href="https://paypal.me/JunyeobBaek"><img src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black" height="35"></a>