### PR TITLE
Add usage history graph and refresh status bar

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,6 +25,24 @@ let tray = null;
 
 const WIDGET_WIDTH = 530;
 const WIDGET_HEIGHT = 155;
+const HISTORY_RETENTION_DAYS = 30;
+const CHART_DAYS = 7;
+
+function storeUsageHistory(data) {
+  const timestamp = Date.now();
+  const history = store.get('usageHistory', []);
+
+  history.push({
+    timestamp,
+    session: data.five_hour?.utilization || 0,
+    weekly: data.seven_day?.utilization || 0,
+    sonnet: data.seven_day_sonnet?.utilization || 0,
+    extraUsage: data.extra_usage?.utilization || 0
+  });
+
+  const cutoff = timestamp - (HISTORY_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+  store.set('usageHistory', history.filter((entry) => entry.timestamp > cutoff));
+}
 
 // Force portable builds to use %APPDATA% so config persists in the same
 // location as the installer version. Without this, portable stores userData
@@ -259,6 +277,14 @@ ipcMain.on('open-external', (event, url) => {
 
 ipcMain.handle('get-app-version', () => {
   return app.getVersion();
+});
+
+ipcMain.handle('get-usage-history', () => {
+  const history = store.get('usageHistory', []);
+  const cutoff = Date.now() - (CHART_DAYS * 24 * 60 * 60 * 1000);
+  return history
+    .filter((entry) => entry.timestamp > cutoff)
+    .sort((a, b) => a.timestamp - b.timestamp);
 });
 
 // Show a native OS desktop notification (Windows toast, macOS NC, Linux libnotify)
@@ -512,6 +538,7 @@ ipcMain.handle('fetch-usage-data', async () => {
     debugLog('Prepaid fetch skipped or failed:', prepaidResult.reason?.message || 'no data');
   }
 
+  storeUsageHistory(data);
   return data;
 });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "electron-builder": "^24.9.1"
   },
   "dependencies": {
+    "chart.js": "^4.5.1",
     "electron-store": "^8.1.0"
   },
   "build": {
@@ -77,7 +78,10 @@
       "target": [
         {
           "target": "AppImage",
-          "arch": ["x64", "arm64"]
+          "arch": [
+            "x64",
+            "arm64"
+          ]
         }
       ],
       "icon": "assets/logo.png",

--- a/preload.js
+++ b/preload.js
@@ -27,6 +27,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // API
   fetchUsageData: () => ipcRenderer.invoke('fetch-usage-data'),
+  getUsageHistory: () => ipcRenderer.invoke('get-usage-history'),
   openExternal: (url) => ipcRenderer.send('open-external', url),
 
   // Platform

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -5,9 +5,14 @@ let countdownInterval = null;
 let latestUsageData = null;
 let isExpanded = false;
 let isCompactMode = false;
+let usageChart = null;
+let graphVisible = false;
+let lastRefreshTime = null;
+let refreshedAgoInterval = null;
 const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const WIDGET_HEIGHT_COLLAPSED = 155;
 const WIDGET_ROW_HEIGHT = 30;
+const GRAPH_HEIGHT = 232;
 
 // Debug logging — only shows in DevTools (development mode).
 // Regular users won't see verbose logs in production.
@@ -33,6 +38,7 @@ const elements = {
     connectBtn: document.getElementById('connectBtn'),
     sessionKeyError: document.getElementById('sessionKeyError'),
     refreshBtn: document.getElementById('refreshBtn'),
+    graphBtn: document.getElementById('graphBtn'),
     minimizeBtn: document.getElementById('minimizeBtn'),
     closeBtn: document.getElementById('closeBtn'),
 
@@ -53,6 +59,10 @@ const elements = {
     expandArrow: document.getElementById('expandArrow'),
     expandSection: document.getElementById('expandSection'),
     extraRows: document.getElementById('extraRows'),
+    graphSection: document.getElementById('graphSection'),
+    usageChart: document.getElementById('usageChart'),
+    statusBar: document.getElementById('statusBar'),
+    refreshedAgo: document.getElementById('refreshedAgo'),
 
     settingsBtn: document.getElementById('settingsBtn'),
     settingsOverlay: document.getElementById('settingsOverlay'),
@@ -166,6 +176,16 @@ function setupEventListeners() {
         elements.refreshBtn.classList.remove('spinning');
     });
 
+    elements.graphBtn.addEventListener('click', async () => {
+        graphVisible = !graphVisible;
+        elements.graphBtn.classList.toggle('active', graphVisible);
+        elements.graphSection.style.display = graphVisible ? 'block' : 'none';
+        if (graphVisible) {
+            await loadChart();
+        }
+        if (!isCompactMode) resizeWidget();
+    });
+
     elements.minimizeBtn.addEventListener('click', () => {
         window.electronAPI.minimizeWindow();
     });
@@ -179,6 +199,9 @@ function setupEventListeners() {
         isExpanded = !isExpanded;
         elements.expandArrow.classList.toggle('expanded', isExpanded);
         elements.expandSection.style.display = isExpanded ? 'block' : 'none';
+        if (graphVisible) {
+            loadChart();
+        }
         resizeWidget();
     });
 
@@ -500,6 +523,7 @@ function refreshExtraTimers() {
 
 const BANNER_HEIGHT = 28;
 const EXPAND_OVERHEAD = 28; // margin-top(12) + padding-top(6) + bottom buffer(10)
+const STATUS_BAR_HEIGHT = 28;
 
 function resizeWidget(bannerVisible) {
     const hasBanner = bannerVisible !== undefined
@@ -507,12 +531,12 @@ function resizeWidget(bannerVisible) {
         : elements.updateBanner.style.display !== 'none';
     const bannerOffset = hasBanner ? BANNER_HEIGHT : 0;
     const extraCount = elements.extraRows.children.length;
-    if (isExpanded && extraCount > 0) {
-        const expandedHeight = WIDGET_HEIGHT_COLLAPSED + EXPAND_OVERHEAD + (extraCount * WIDGET_ROW_HEIGHT) + bannerOffset;
-        window.electronAPI.resizeWindow(expandedHeight);
-    } else {
-        window.electronAPI.resizeWindow(WIDGET_HEIGHT_COLLAPSED + bannerOffset);
-    }
+    const expandedOffset = isExpanded && extraCount > 0
+        ? EXPAND_OVERHEAD + (extraCount * WIDGET_ROW_HEIGHT)
+        : 0;
+    const graphOffset = graphVisible ? GRAPH_HEIGHT : 0;
+    const totalHeight = WIDGET_HEIGHT_COLLAPSED + expandedOffset + graphOffset + STATUS_BAR_HEIGHT + bannerOffset;
+    window.electronAPI.resizeWindow(totalHeight);
 }
 
 function updateUI(data) {
@@ -529,6 +553,12 @@ function updateUI(data) {
     if (isExpanded) refreshExtraTimers();
     if (!isCompactMode) resizeWidget();
     startCountdown();
+    lastRefreshTime = Date.now();
+    updateRefreshedAgo();
+    startRefreshedAgoTimer();
+    if (graphVisible) {
+        loadChart();
+    }
 
     // Update compact bars in parallel if compact mode is active
     if (isCompactMode) updateCompactBars(data);
@@ -612,6 +642,12 @@ function applyCompactMode(compact) {
         elements.expandSection.style.display = 'none';
     }
 
+    if (compact && graphVisible) {
+        graphVisible = false;
+        elements.graphBtn.classList.remove('active');
+        elements.graphSection.style.display = 'none';
+    }
+
     // Show/hide the collapse chevron (only visible in normal mode with data)
     if (elements.compactCollapseBtn) {
         elements.compactCollapseBtn.style.display = compact ? 'none' : 'flex';
@@ -620,6 +656,12 @@ function applyCompactMode(compact) {
     // Hide refresh button in compact mode (no room, and refresh causes resize issues)
     if (elements.refreshBtn) {
         elements.refreshBtn.style.display = compact ? 'none' : '';
+    }
+    if (elements.graphBtn) {
+        elements.graphBtn.style.display = compact ? 'none' : '';
+    }
+    if (elements.statusBar) {
+        elements.statusBar.style.display = compact ? 'none' : 'block';
     }
 
     // Tell main process to resize the window width
@@ -631,6 +673,7 @@ function applyCompactMode(compact) {
 
     // Update compact bars if we have data
     if (compact && latestUsageData) updateCompactBars(latestUsageData);
+    if (!compact) resizeWidget();
 }
 
 // Update the compact mode progress bars
@@ -930,6 +973,9 @@ function showMainContent() {
     if (elements.compactCollapseBtn) {
         elements.compactCollapseBtn.style.display = isCompactMode ? 'none' : 'flex';
     }
+    if (elements.statusBar) {
+        elements.statusBar.style.display = isCompactMode ? 'none' : 'block';
+    }
 }
 
 // Auto-update management
@@ -945,6 +991,236 @@ function stopAutoUpdate() {
         clearInterval(updateInterval);
         updateInterval = null;
     }
+}
+
+function updateRefreshedAgo() {
+    if (!lastRefreshTime) return;
+
+    const diffMs = Date.now() - lastRefreshTime;
+    const minutes = Math.floor(diffMs / 60000);
+
+    if (minutes <= 0) {
+        elements.refreshedAgo.textContent = 'Refreshed just now';
+    } else if (minutes === 1) {
+        elements.refreshedAgo.textContent = 'Refreshed 1 minute ago';
+    } else {
+        elements.refreshedAgo.textContent = `Refreshed ${minutes} minutes ago`;
+    }
+}
+
+function startRefreshedAgoTimer() {
+    if (refreshedAgoInterval) clearInterval(refreshedAgoInterval);
+    refreshedAgoInterval = setInterval(updateRefreshedAgo, 30000);
+}
+
+async function loadChart() {
+    const history = await window.electronAPI.getUsageHistory();
+    if (!history.length) return;
+    renderChart(history);
+}
+
+function renderChart(history) {
+    if (usageChart) usageChart.destroy();
+
+    const showSonnet = isExpanded && !!latestUsageData?.seven_day_sonnet;
+    const showExtraUsage = isExpanded && !!latestUsageData?.extra_usage;
+    const allValues = history.flatMap((entry) => {
+        const values = [entry.session, entry.weekly];
+        if (showSonnet) values.push(entry.sonnet || 0);
+        if (showExtraUsage) values.push(entry.extraUsage || 0);
+        return values;
+    });
+    const yMax = Math.max(10, Math.ceil(Math.max(...allValues) / 10) * 10);
+
+    const datasets = [
+        {
+            label: 'Session',
+            data: history.map((entry) => entry.session),
+            borderColor: '#8b5cf6',
+            backgroundColor: 'transparent',
+            borderWidth: 2,
+            stepped: true,
+            pointRadius: 0,
+            pointHoverRadius: 3,
+            pointHitRadius: 10
+        },
+        {
+            label: 'Weekly',
+            data: history.map((entry) => entry.weekly),
+            borderColor: '#3b82f6',
+            backgroundColor: 'transparent',
+            borderWidth: 2,
+            stepped: true,
+            pointRadius: 0,
+            pointHoverRadius: 3,
+            pointHitRadius: 10
+        }
+    ];
+
+    if (showSonnet) {
+        const sonnetData = history.map((entry) => entry.sonnet || 0);
+        if (sonnetData.some((value) => value > 0)) {
+            datasets.push({
+            label: 'Sonnet',
+            data: sonnetData,
+            borderColor: '#10b981',
+            backgroundColor: 'transparent',
+            borderWidth: 2,
+            stepped: true,
+            pointRadius: 0,
+            pointHoverRadius: 3,
+            pointHitRadius: 10
+            });
+        }
+    }
+
+    if (showExtraUsage) {
+        const extraUsageData = history.map((entry) => entry.extraUsage || 0);
+        if (extraUsageData.some((value) => value > 0)) {
+            datasets.push({
+            label: 'Extra Usage',
+            data: extraUsageData,
+            borderColor: '#f59e0b',
+            backgroundColor: 'transparent',
+            borderWidth: 2,
+            stepped: true,
+            pointRadius: 0,
+            pointHoverRadius: 3,
+            pointHitRadius: 10
+            });
+        }
+    }
+
+    usageChart = new Chart(elements.usageChart.getContext('2d'), {
+        type: 'line',
+        data: {
+            labels: history.map((entry) => entry.timestamp),
+            datasets
+        },
+        options: {
+            animation: false,
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: {
+                intersect: false,
+                mode: 'nearest'
+            },
+            scales: {
+                x: {
+                    offset: true,
+                    ticks: {
+                        autoSkip: false,
+                        maxRotation: 0,
+                        minRotation: 0,
+                        font: {
+                            size: 10
+                        },
+                        callback(value, index) {
+                            return formatXAxisTick(history, index);
+                        }
+                    },
+                    grid: {
+                        display: false
+                    }
+                },
+                y: {
+                    min: 0,
+                    max: yMax,
+                    ticks: {
+                        font: {
+                            size: 10
+                        },
+                        callback: (value) => `${value}%`
+                    },
+                    grid: {
+                        color: 'rgba(255, 255, 255, 0.05)'
+                    }
+                }
+            },
+            plugins: {
+                legend: {
+                    display: false
+                },
+                tooltip: {
+                    callbacks: {
+                        title(items) {
+                            const point = history[items[0].dataIndex];
+                            return new Date(point.timestamp).toLocaleString([], {
+                                month: 'short',
+                                day: 'numeric',
+                                hour: 'numeric',
+                                minute: '2-digit'
+                            });
+                        },
+                        label(item) {
+                            return `${item.dataset.label}: ${Math.round(item.parsed.y)}%`;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+function formatXAxisTick(history, index) {
+    const tickIndexes = getXAxisTickIndexes(history.length);
+    if (!tickIndexes.has(index)) {
+        return '';
+    }
+
+    const timestamp = history[index]?.timestamp;
+    if (!timestamp) {
+        return '';
+    }
+
+    const spanMs = Math.max(0, history[history.length - 1].timestamp - history[0].timestamp);
+    const date = new Date(timestamp);
+
+    if (spanMs < 12 * 60 * 60 * 1000) {
+        return date.toLocaleTimeString([], {
+            hour: 'numeric',
+            minute: '2-digit'
+        });
+    }
+
+    if (spanMs < 48 * 60 * 60 * 1000) {
+        return date.toLocaleString([], {
+            weekday: 'short',
+            hour: 'numeric'
+        });
+    }
+
+    return date.toLocaleDateString([], {
+        month: 'short',
+        day: 'numeric'
+    });
+}
+
+function getXAxisTickIndexes(length) {
+    const indexes = new Set();
+    if (length <= 0) {
+        return indexes;
+    }
+
+    indexes.add(0);
+    if (length === 1) {
+        return indexes;
+    }
+
+    const targetTickCount = Math.min(5, length);
+    const lastIndex = length - 1;
+    indexes.add(lastIndex);
+
+    if (targetTickCount <= 2) {
+        return indexes;
+    }
+
+    const interval = lastIndex / (targetTickCount - 1);
+    for (let i = 1; i < targetTickCount - 1; i += 1) {
+        indexes.add(Math.round(interval * i));
+    }
+
+    return indexes;
 }
 
 // Add spinning animation for refresh button
@@ -1064,4 +1340,5 @@ init();
 window.addEventListener('beforeunload', () => {
     stopAutoUpdate();
     if (countdownInterval) clearInterval(countdownInterval);
+    if (refreshedAgoInterval) clearInterval(refreshedAgoInterval);
 });

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <script src="../../node_modules/chart.js/dist/chart.umd.js"></script>
 </head>
 
 <body>
@@ -27,6 +28,11 @@
                             stroke-width="2">
                             <path d="M23 4v6h-6M1 20v-6h6" />
                             <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+                        </svg>
+                    </button>
+                    <button class="control-btn graph-btn" id="graphBtn" title="Toggle Usage Graph">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
                         </svg>
                     </button>
                     <button class="control-btn minimize-btn" id="minimizeBtn" title="Minimise to System Tray">−</button>
@@ -169,6 +175,14 @@
                 <!-- Expandable Details -->
                 <div class="expand-section" id="expandSection" style="display: none;">
                     <div id="extraRows"></div>
+                </div>
+
+                <div class="graph-section" id="graphSection" style="display: none;">
+                    <canvas id="usageChart"></canvas>
+                </div>
+
+                <div class="status-bar" id="statusBar">
+                    <span id="refreshedAgo">Refreshed just now</span>
                 </div>
 
             </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -464,6 +464,33 @@ body {
     padding-top: 6px;
 }
 
+.graph-section {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    margin-top: 12px;
+    padding: 14px 16px 8px 12px;
+    height: 220px;
+}
+
+.graph-section canvas {
+    width: 100% !important;
+    height: 100% !important;
+}
+
+.graph-btn.active {
+    background: rgba(139, 92, 246, 0.22);
+}
+
+.status-bar {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    margin-top: 10px;
+    padding: 6px 0 4px;
+    color: #666;
+    font-size: 10px;
+    text-align: center;
+    width: 100%;
+    box-sizing: border-box;
+}
+
 .expand-section .usage-section {
     height: 28px;
     margin-bottom: 0;


### PR DESCRIPTION
## Summary

This PR adds a toggleable usage history graph to the widget and restores a lightweight refresh status bar.

It is intentionally scoped to the graph/status-bar feature set discussed in the earlier review, without bundling unrelated login, config, build, or platform changes.

cc @Hackpig1974

## What’s Included

- Add a toolbar button to show/hide a usage history graph
- Persist usage snapshots locally in `electron-store`
- Render up to 7 days of stored usage history
- Add a `Refreshed X minutes ago` status bar
- Show exact timestamp + value in the graph tooltip
- Add sparse adaptive x-axis labels so the chart remains readable at different history spans
- Only show optional datasets when they are relevant to the current UI state
- Skip rendering optional lines when their visible history is all zero

## Notes on Graph Behavior

- The graph always includes `Session` and `Weekly`
- `Sonnet` and `Extra Usage` are only shown when those sections are relevant/visible in the current widget view
- Optional lines are omitted if their visible history window is entirely zero
- Tooltip interaction follows the nearest series rather than showing every series at that timestamp
- The x-axis always labels the first and last visible points, with a few adaptive labels in between

## Implementation Notes

- Usage snapshots are stored in `electron-store` and filtered to the last 7 days for display
- The status bar is kept in normal content flow rather than pinned as a separate footer
- Window-height sizing remains explicit and conservative because the widget already uses manual Electron resizing across collapsed, expanded, and graph-visible states

## Testing

Tested locally by:
- launching the Electron app from current upstream `main`
- toggling graph visibility
- verifying collapsed / expanded / graph-visible states
- checking tooltip timestamps and single-series hover behavior
- verifying optional lines appear only when relevant
- verifying zero-only optional datasets are not rendered
- checking x-axis readability with a small number of points and with persisted history
