### PR TITLE
Fix macOS restore behavior after minimize

### DIFF
--- a/main.js
+++ b/main.js
@@ -103,7 +103,9 @@ function createTray() {
         label: 'Show Widget',
         click: () => {
           if (mainWindow) {
+            if (mainWindow.isMinimized()) mainWindow.restore();
             mainWindow.show();
+            mainWindow.focus();
           } else {
             createMainWindow();
           }
@@ -151,7 +153,13 @@ function createTray() {
 
     tray.on('click', () => {
       if (mainWindow) {
-        mainWindow.isVisible() ? mainWindow.hide() : mainWindow.show();
+        if (mainWindow.isVisible() && !mainWindow.isMinimized()) {
+          mainWindow.hide();
+        } else {
+          if (mainWindow.isMinimized()) mainWindow.restore();
+          mainWindow.show();
+          mainWindow.focus();
+        }
       }
     });
   } catch (error) {
@@ -225,7 +233,7 @@ ipcMain.handle('validate-session-key', async (event, sessionKey) => {
 });
 
 ipcMain.on('minimize-window', () => {
-  if (mainWindow) mainWindow.hide();
+  if (mainWindow) mainWindow.minimize();
 });
 
 ipcMain.on('close-window', () => {
@@ -548,6 +556,10 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
   if (mainWindow === null) {
     createMainWindow();
+  } else {
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.show();
+    mainWindow.focus();
   }
 });
 


### PR DESCRIPTION
## Summary

This PR fixes a macOS restore bug where the widget could be minimized/hidden and then fail to come back when the app was activated again.

## Problem

The custom minimize path was calling `mainWindow.hide()`, but the macOS `activate` handler only recreated the window when `mainWindow === null`. If the window still existed but had been hidden, clicking the Dock icon would activate the app without restoring the widget.

## Fix

- Use `mainWindow.minimize()` for the custom minimize action
- Update Dock/tray restore paths to call `restore()`, `show()`, and `focus()` when needed
- Update `app.on('activate')` to restore/show an existing hidden or minimized window instead of only handling the null-window case

## Testing

Tested locally in the packaged arm64 macOS app by:
- launching the app
- minimizing it with the custom button
- restoring it again via normal macOS activation behavior
- verifying the widget reliably returns instead of remaining hidden
