### PR TITLE
feat: macOS menu bar mode — no Dock icon, popup on left click

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,26 +7,21 @@ const { fetchViaWindow, fetchMultipleViaWindow } = require('./src/fetch-via-wind
 const GITHUB_OWNER = 'SlavomirDurej';
 const GITHUB_REPO = 'claude-usage-widget';
 
-// Migration: Handle old encrypted config files from v1.7.0 and earlier
-// Must happen BEFORE creating Store instance to prevent parse errors
 const fs = require('fs');
 const os = require('os');
 
-// electron-store uses different paths per platform
 let configPath;
 if (process.platform === 'darwin') {
   configPath = path.join(os.homedir(), 'Library', 'Application Support', 'claude-usage-widget', 'config.json');
 } else if (process.platform === 'win32') {
   configPath = path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'claude-usage-widget', 'config.json');
 } else {
-  // Linux
   configPath = path.join(os.homedir(), '.config', 'claude-usage-widget', 'config.json');
 }
 
 try {
   if (fs.existsSync(configPath)) {
     const rawData = fs.readFileSync(configPath, 'utf-8');
-    // Check if file looks encrypted (contains non-JSON garbage or doesn't start with {)
     if (rawData.includes('\u0000') || !rawData.trim().startsWith('{')) {
       console.log('[Migration] Detected old encrypted config from v1.7.0, deleting for fresh start');
       fs.unlinkSync(configPath);
@@ -34,17 +29,13 @@ try {
   }
 } catch (err) {
   console.error('[Migration] Error checking config file:', err.message);
-  // If we can't read it, try to delete it
   try {
     if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
   } catch {}
 }
 
-// Non-sensitive settings storage (no encryption needed)
 const store = new Store();
 
-// Debug mode: set DEBUG_LOG=1 env var or pass --debug flag to see verbose logs.
-// Regular users will only see critical errors in the console.
 const DEBUG = process.env.DEBUG_LOG === '1' || process.argv.includes('--debug');
 function debugLog(...args) {
   if (DEBUG) console.log('[Debug]', ...args);
@@ -53,19 +44,17 @@ function debugLog(...args) {
 const CHROME_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
 let mainWindow = null;
-let sessionTray = null;  // Tray icon for Session usage
-let weeklyTray = null;   // Tray icon for Weekly usage
+let sessionTray = null; // Single menu bar icon
 
 const WIDGET_WIDTH = process.platform === 'darwin' ? 590 : 560;
 const WIDGET_HEIGHT = 155;
 const HISTORY_RETENTION_DAYS = 30;
 const CHART_DAYS = 7;
-const MAX_HISTORY_SAMPLES = 10000; // Cap total samples to prevent unbounded growth
+const MAX_HISTORY_SAMPLES = 10000;
 
 function storeUsageHistory(data) {
   const timestamp = Date.now();
   let history = store.get('usageHistory', []);
-
   history.push({
     timestamp,
     session: data.five_hour?.utilization || 0,
@@ -73,25 +62,18 @@ function storeUsageHistory(data) {
     sonnet: data.seven_day_sonnet?.utilization || 0,
     extraUsage: data.extra_usage?.utilization || 0
   });
-
-  // Rotation: apply both time-based and count-based limits
   const cutoff = timestamp - (HISTORY_RETENTION_DAYS * 24 * 60 * 60 * 1000);
   history = history.filter((entry) => entry.timestamp > cutoff);
-
-  // If still over limit, drop oldest samples
   if (history.length > MAX_HISTORY_SAMPLES) {
     history = history.slice(history.length - MAX_HISTORY_SAMPLES);
   }
-
   store.set('usageHistory', history);
 }
 
-// Set session-level User-Agent to avoid Electron detection
 app.on('ready', () => {
   session.defaultSession.setUserAgent(CHROME_USER_AGENT);
 });
 
-// Set sessionKey as a cookie in Electron's session
 async function setSessionCookie(sessionKey) {
   await session.defaultSession.cookies.set({
     url: 'https://claude.ai',
@@ -105,8 +87,17 @@ async function setSessionCookie(sessionKey) {
   debugLog('sessionKey cookie set in Electron session');
 }
 
+// Position popup just below the tray icon
+function positionWindowBelowTray(trayRef) {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  const trayBounds = trayRef.getBounds();
+  const windowBounds = mainWindow.getBounds();
+  const x = Math.round(trayBounds.x + trayBounds.width / 2 - windowBounds.width / 2);
+  const y = Math.round(trayBounds.y + trayBounds.height + 2);
+  mainWindow.setPosition(x, y, false);
+}
+
 function createMainWindow() {
-  const savedPosition = store.get('windowPosition');
   const windowOptions = {
     width: WIDGET_WIDTH,
     height: WIDGET_HEIGHT,
@@ -114,7 +105,8 @@ function createMainWindow() {
     transparent: true,
     alwaysOnTop: true,
     resizable: false,
-    skipTaskbar: false,
+    skipTaskbar: true,
+    show: false, // Hidden on launch — appears on tray click
     icon: path.join(__dirname, process.platform === 'darwin' ? 'assets/icon.icns' : process.platform === 'linux' ? 'assets/logo.png' : 'assets/icon.ico'),
     webPreferences: {
       nodeIntegration: false,
@@ -123,21 +115,14 @@ function createMainWindow() {
     }
   };
 
-  if (savedPosition) {
-    windowOptions.x = savedPosition.x;
-    windowOptions.y = savedPosition.y;
-  }
-
   mainWindow = new BrowserWindow(windowOptions);
   mainWindow.loadFile('src/renderer/index.html');
 
-  let positionSaveTimer = null;
-  mainWindow.on('move', () => {
-    if (positionSaveTimer) clearTimeout(positionSaveTimer);
-    positionSaveTimer = setTimeout(() => {
-      const position = mainWindow.getBounds();
-      store.set('windowPosition', { x: position.x, y: position.y });
-    }, 300);
+  // Hide popup when user clicks anywhere outside it
+  mainWindow.on('blur', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.hide();
+    }
   });
 
   mainWindow.on('closed', () => {
@@ -149,209 +134,44 @@ function createMainWindow() {
   }
 }
 
-/**
- * Determine background color based on thresholds
- */
 function getBackgroundColor(percent, isSession, warnThreshold, dangerThreshold) {
   if (percent >= dangerThreshold) {
-    // Red #ef4444
     return { r: 239, g: 68, b: 68 };
   } else if (percent >= warnThreshold) {
-    // Amber/Orange #f59e0b
     return { r: 245, g: 158, b: 11 };
   } else {
-    // Default colors
     if (isSession) {
-      // Purple #8b5cf6
       return { r: 139, g: 92, b: 246 };
     } else {
-      // Blue #3b82f6
       return { r: 59, g: 130, b: 246 };
     }
   }
 }
 
-/**
- * Bold 8x11 bitmap font for numbers 0-9 (2-pixel strokes for bold look)
- * Each number is represented as an array of 11 rows, each row is 8 bits
- */
 const BITMAP_FONT = {
-  '0': [
-    0b00111100,
-    0b01111110,
-    0b11100111,
-    0b11000011,
-    0b11000011,
-    0b11000011,
-    0b11000011,
-    0b11000011,
-    0b11100111,
-    0b01111110,
-    0b00111100
-  ],
-  '1': [
-    0b00011000,
-    0b00111000,
-    0b01111000,
-    0b00011000,
-    0b00011000,
-    0b00011000,
-    0b00011000,
-    0b00011000,
-    0b00011000,
-    0b01111110,
-    0b01111110
-  ],
-  '2': [
-    0b00111100,
-    0b01111110,
-    0b11100111,
-    0b00000011,
-    0b00000110,
-    0b00011100,
-    0b00111000,
-    0b01110000,
-    0b11100000,
-    0b11111111,
-    0b11111111
-  ],
-  '3': [
-    0b00111100,
-    0b01111110,
-    0b11100111,
-    0b00000011,
-    0b00000110,
-    0b00111100,
-    0b00000110,
-    0b00000011,
-    0b11100111,
-    0b01111110,
-    0b00111100
-  ],
-  '4': [
-    0b00000110,
-    0b00001110,
-    0b00011110,
-    0b00110110,
-    0b01100110,
-    0b11111111,
-    0b11111111,
-    0b00000110,
-    0b00000110,
-    0b00000110,
-    0b00000110
-  ],
-  '5': [
-    0b11111111,
-    0b11111111,
-    0b11000000,
-    0b11000000,
-    0b11111100,
-    0b00000110,
-    0b00000011,
-    0b00000011,
-    0b11100111,
-    0b01111110,
-    0b00111100
-  ],
-  '6': [
-    0b00111100,
-    0b01111110,
-    0b11100000,
-    0b11000000,
-    0b11111100,
-    0b11100110,
-    0b11000011,
-    0b11000011,
-    0b11100111,
-    0b01111110,
-    0b00111100
-  ],
-  '7': [
-    0b11111111,
-    0b11111111,
-    0b00000011,
-    0b00000110,
-    0b00001100,
-    0b00011000,
-    0b00110000,
-    0b00110000,
-    0b01100000,
-    0b01100000,
-    0b01100000
-  ],
-  '8': [
-    0b00111100,
-    0b01111110,
-    0b11100111,
-    0b11000011,
-    0b01111110,
-    0b00111100,
-    0b01111110,
-    0b11000011,
-    0b11100111,
-    0b01111110,
-    0b00111100
-  ],
-  '9': [
-    0b00111100,
-    0b01111110,
-    0b11100111,
-    0b11000011,
-    0b11000011,
-    0b01111111,
-    0b00111111,
-    0b00000011,
-    0b00000111,
-    0b01111110,
-    0b00111100
-  ]
+  '0': [0b00111100,0b01111110,0b11100111,0b11000011,0b11000011,0b11000011,0b11000011,0b11000011,0b11100111,0b01111110,0b00111100],
+  '1': [0b00011000,0b00111000,0b01111000,0b00011000,0b00011000,0b00011000,0b00011000,0b00011000,0b00011000,0b01111110,0b01111110],
+  '2': [0b00111100,0b01111110,0b11100111,0b00000011,0b00000110,0b00011100,0b00111000,0b01110000,0b11100000,0b11111111,0b11111111],
+  '3': [0b00111100,0b01111110,0b11100111,0b00000011,0b00000110,0b00111100,0b00000110,0b00000011,0b11100111,0b01111110,0b00111100],
+  '4': [0b00000110,0b00001110,0b00011110,0b00110110,0b01100110,0b11111111,0b11111111,0b00000110,0b00000110,0b00000110,0b00000110],
+  '5': [0b11111111,0b11111111,0b11000000,0b11000000,0b11111100,0b00000110,0b00000011,0b00000011,0b11100111,0b01111110,0b00111100],
+  '6': [0b00111100,0b01111110,0b11100000,0b11000000,0b11111100,0b11100110,0b11000011,0b11000011,0b11100111,0b01111110,0b00111100],
+  '7': [0b11111111,0b11111111,0b00000011,0b00000110,0b00001100,0b00011000,0b00110000,0b00110000,0b01100000,0b01100000,0b01100000],
+  '8': [0b00111100,0b01111110,0b11100111,0b11000011,0b01111110,0b00111100,0b01111110,0b11000011,0b11100111,0b01111110,0b00111100],
+  '9': [0b00111100,0b01111110,0b11100111,0b11000011,0b11000011,0b01111111,0b00111111,0b00000011,0b00000111,0b01111110,0b00111100]
 };
 
-/**
- * Narrow 6x11 bitmap font for 3-digit numbers (100%)
- * Bold version to match
- */
 const BITMAP_FONT_NARROW = {
-  '0': [
-    0b011110,
-    0b111111,
-    0b110011,
-    0b110011,
-    0b110011,
-    0b110011,
-    0b110011,
-    0b110011,
-    0b110011,
-    0b111111,
-    0b011110
-  ],
-  '1': [
-    0b001100,
-    0b011100,
-    0b111100,
-    0b001100,
-    0b001100,
-    0b001100,
-    0b001100,
-    0b001100,
-    0b001100,
-    0b111111,
-    0b111111
-  ]
+  '0': [0b011110,0b111111,0b110011,0b110011,0b110011,0b110011,0b110011,0b110011,0b110011,0b111111,0b011110],
+  '1': [0b001100,0b011100,0b111100,0b001100,0b001100,0b001100,0b001100,0b001100,0b001100,0b111111,0b111111]
 };
 
-/**
- * Draw a crisp bitmap character at position (x, y) in the buffer
- */
 function drawChar(buffer, width, height, char, x, y, color, useNarrow = false) {
   const bitmap = useNarrow ? BITMAP_FONT_NARROW[char] : BITMAP_FONT[char];
   if (!bitmap) return useNarrow ? 6 : 8;
-  
   const charWidth = useNarrow ? 6 : 8;
   const charHeight = 11;
   const maxCol = useNarrow ? 5 : 7;
-  
   for (let row = 0; row < charHeight; row++) {
     for (let col = 0; col < charWidth; col++) {
       if (bitmap[row] & (1 << (maxCol - col))) {
@@ -370,18 +190,10 @@ function drawChar(buffer, width, height, char, x, y, color, useNarrow = false) {
   return charWidth;
 }
 
-/**
- * Generate a single percentage badge icon with colored background and bitmap text
- * @param {number} percent - Usage percentage (0-100)
- * @param {object} bgColor - Background color {r, g, b}
- * @returns {NativeImage} Generated tray icon
- */
 function generatePercentageIcon(percent, bgColor) {
-  const width = 20;  // Back to 20x20
+  const width = 20;
   const height = 20;
   const buffer = Buffer.alloc(width * height * 4);
-  
-  // Draw filled square background
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       const offset = (y * width + x) * 4;
@@ -391,40 +203,27 @@ function generatePercentageIcon(percent, bgColor) {
       buffer[offset + 3] = 255;
     }
   }
-  
-  // Draw white text
   const percentText = Math.round(percent).toString();
   const textColor = { r: 255, g: 255, b: 255, a: 255 };
-  
-  // Use narrow font for 3-digit numbers (100%)
   const useNarrow = percentText.length >= 3;
   const charWidth = useNarrow ? 6 : 8;
   const charHeight = 11;
-  const gap = percentText.length >= 3 ? 0 : 1; // 1px gap for 1-2 digits, no gap for 100
+  const gap = percentText.length >= 3 ? 0 : 1;
   const totalWidth = percentText.length * charWidth + (percentText.length - 1) * gap;
   let startX = Math.floor((width - totalWidth) / 2);
   const startY = Math.floor((height - charHeight) / 2);
-  
-  // Draw each digit
   for (let i = 0; i < percentText.length; i++) {
     drawChar(buffer, width, height, percentText[i], startX, startY, textColor, useNarrow);
     startX += charWidth + gap;
   }
-  
   return nativeImage.createFromBuffer(buffer, { width, height });
 }
 
-/**
- * Generate a Red X icon for 99-100% usage (maxed out)
- * @returns {NativeImage} Generated red X tray icon
- */
 function generateRedXIcon() {
   const width = 20;
   const height = 20;
   const buffer = Buffer.alloc(width * height * 4);
-  
-  // Red background
-  const red = { r: 220, g: 53, b: 69 }; // #dc3545
+  const red = { r: 220, g: 53, b: 69 };
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       const offset = (y * width + x) * 4;
@@ -434,65 +233,36 @@ function generateRedXIcon() {
       buffer[offset + 3] = 255;
     }
   }
-  
-  // Draw white X (2 pixel thick lines)
   const white = { r: 255, g: 255, b: 255, a: 255 };
-  
-  // Diagonal line from top-left to bottom-right
   for (let i = 0; i < 11; i++) {
-    const x1 = 5 + i;
-    const y1 = 5 + i;
-    // Draw 2x2 pixel for thickness
+    const x1 = 5 + i; const y1 = 5 + i;
     for (let dy = 0; dy < 2; dy++) {
       for (let dx = 0; dx < 2; dx++) {
-        const px = x1 + dx;
-        const py = y1 + dy;
+        const px = x1 + dx; const py = y1 + dy;
         if (px < width && py < height) {
           const offset = (py * width + px) * 4;
-          buffer[offset] = white.b;
-          buffer[offset + 1] = white.g;
-          buffer[offset + 2] = white.r;
-          buffer[offset + 3] = white.a;
+          buffer[offset] = white.b; buffer[offset + 1] = white.g;
+          buffer[offset + 2] = white.r; buffer[offset + 3] = white.a;
         }
       }
     }
   }
-  
-  // Diagonal line from top-right to bottom-left
   for (let i = 0; i < 11; i++) {
-    const x1 = 15 - i;
-    const y1 = 5 + i;
-    // Draw 2x2 pixel for thickness
+    const x1 = 15 - i; const y1 = 5 + i;
     for (let dy = 0; dy < 2; dy++) {
       for (let dx = 0; dx < 2; dx++) {
-        const px = x1 + dx;
-        const py = y1 + dy;
+        const px = x1 + dx; const py = y1 + dy;
         if (px < width && py < height) {
           const offset = (py * width + px) * 4;
-          buffer[offset] = white.b;
-          buffer[offset + 1] = white.g;
-          buffer[offset + 2] = white.r;
-          buffer[offset + 3] = white.a;
+          buffer[offset] = white.b; buffer[offset + 1] = white.g;
+          buffer[offset + 2] = white.r; buffer[offset + 3] = white.a;
         }
       }
     }
   }
-  
   return nativeImage.createFromBuffer(buffer, { width, height });
 }
 
-
-
-/**
- * Show the main window without the double-blink artifact on Windows.
- *
- * On Windows, transparent + alwaysOnTop + frameless windows re-enter the DWM
- * compositing pipeline in two steps when shown after hide(): an initial layered
- * window render (blink 1) followed by the alwaysOnTop z-order re-assertion
- * (blink 2). Setting opacity to 0 before show() masks those intermediate states;
- * the window is made opaque again after the DWM has had time to settle (~3 frames).
- * macOS and Linux do not have this issue so they just call show() directly.
- */
 function showMainWindowClean() {
   if (!mainWindow || mainWindow.isDestroyed()) return;
   if (mainWindow.isMinimized()) mainWindow.restore();
@@ -509,22 +279,23 @@ function showMainWindowClean() {
 
 function createTray() {
   try {
-    const staticIconPath = path.join(__dirname, process.platform === 'darwin' ? 'assets/tray-icon-mac.png' : process.platform === 'linux' ? 'assets/tray-icon-linux.png' : 'assets/tray-icon.png');
-    
-    // Create Weekly tray icon FIRST (left position, blue)
-    weeklyTray = new Tray(staticIconPath);
-    weeklyTray.setToolTip('Weekly Usage');
-    
-    // Create Session tray icon SECOND (right position, purple)
+    const staticIconPath = path.join(__dirname,
+      process.platform === 'darwin' ? 'assets/tray-icon-mac.png' :
+      process.platform === 'linux'  ? 'assets/tray-icon-linux.png' :
+                                       'assets/tray-icon.png');
+
+    // Single icon in the menu bar
     sessionTray = new Tray(staticIconPath);
-    sessionTray.setToolTip('Session Usage');
+    sessionTray.setToolTip('Claude Usage');
 
     const contextMenu = Menu.buildFromTemplate([
       {
         label: 'Show Widget',
         click: () => {
           if (mainWindow) {
+            positionWindowBelowTray(sessionTray);
             showMainWindowClean();
+            mainWindow.focus();
           } else {
             createMainWindow();
           }
@@ -533,9 +304,7 @@ function createTray() {
       {
         label: 'Refresh',
         click: () => {
-          if (mainWindow) {
-            mainWindow.webContents.send('refresh-usage');
-          }
+          if (mainWindow) mainWindow.webContents.send('refresh-usage');
         }
       },
       { type: 'separator' },
@@ -544,7 +313,6 @@ function createTray() {
         click: async () => {
           store.delete('sessionKey');
           store.delete('organizationId');
-          // Clear all Claude.ai cookies and session storage
           const cookies = await session.defaultSession.cookies.get({ url: 'https://claude.ai' });
           for (const cookie of cookies) {
             await session.defaultSession.cookies.remove('https://claude.ai', cookie.name);
@@ -553,119 +321,74 @@ function createTray() {
             storages: ['localstorage', 'sessionstorage', 'cachestorage'],
             origin: 'https://claude.ai'
           });
-          if (mainWindow) {
-            mainWindow.webContents.send('session-expired');
-          }
+          if (mainWindow) mainWindow.webContents.send('session-expired');
         }
       },
       { type: 'separator' },
-      {
-        label: 'Exit',
-        click: () => {
-          app.quit();
-        }
-      }
+      { label: 'Exit', click: () => app.quit() }
     ]);
 
-    sessionTray.setContextMenu(contextMenu);
-    weeklyTray.setContextMenu(contextMenu);
+    // Left click — toggle popup
+    sessionTray.on('click', () => {
+      if (!mainWindow) return;
+      if (mainWindow.isVisible()) {
+        mainWindow.hide();
+      } else {
+        positionWindowBelowTray(sessionTray);
+        showMainWindowClean();
+        mainWindow.focus();
+      }
+    });
 
-    // Click handlers - swapped order
-        weeklyTray.on('click', () => {
-      if (mainWindow) {
-        if (mainWindow.isVisible() && !mainWindow.isMinimized()) {
-          mainWindow.hide();
-        } else {
-          showMainWindowClean();
-        }
-      }
+    // Right click — context menu
+    sessionTray.on('right-click', () => {
+      sessionTray.popUpContextMenu(contextMenu);
     });
-    
-        sessionTray.on('click', () => {
-      if (mainWindow) {
-        if (mainWindow.isVisible() && !mainWindow.isMinimized()) {
-          mainWindow.hide();
-        } else {
-          showMainWindowClean();
-        }
-      }
-    });
+
   } catch (error) {
     console.error('Failed to create tray:', error);
   }
 }
 
-/**
- * Update tray icons with current usage data
- * @param {Object} usageData - Usage data object containing session and weekly percentages
- */
+// Update the tray icon with current usage percentage.
+// When showTrayStats is false, keep the static icon so there's always a menu bar icon.
 function updateTrayIcon(usageData) {
+  if (!sessionTray || sessionTray.isDestroyed()) return;
+
   const showTrayStats = store.get('settings.showTrayStats', false);
-  
+  const staticIconPath = path.join(__dirname,
+    process.platform === 'darwin' ? 'assets/tray-icon-mac.png' :
+    process.platform === 'linux'  ? 'assets/tray-icon-linux.png' :
+                                     'assets/tray-icon.png');
+
   if (!showTrayStats) {
-    // Destroy both tray icons when feature is disabled
-    if (sessionTray && !sessionTray.isDestroyed()) {
-      sessionTray.destroy();
-      sessionTray = null;
-    }
-    if (weeklyTray && !weeklyTray.isDestroyed()) {
-      weeklyTray.destroy();
-      weeklyTray = null;
-    }
+    sessionTray.setImage(staticIconPath);
+    sessionTray.setToolTip('Claude Usage');
     return;
   }
 
-  // Recreate tray icons if they were destroyed
-  if (!sessionTray || sessionTray.isDestroyed() || !weeklyTray || weeklyTray.isDestroyed()) {
-    createTray();
-  }
-
-  if ((!sessionTray || sessionTray.isDestroyed()) && (!weeklyTray || weeklyTray.isDestroyed())) return;
-
-  // Get threshold settings
-  const warnThreshold = store.get('settings.warnThreshold', 75);
+  const warnThreshold   = store.get('settings.warnThreshold', 75);
   const dangerThreshold = store.get('settings.dangerThreshold', 90);
-
-  // Extract percentages from usage data
-  const sessionPercent = usageData?.five_hour?.utilization || 0;
-  const weeklyPercent = usageData?.seven_day?.utilization || 0;
+  const sessionPercent  = usageData?.five_hour?.utilization || 0;
 
   try {
-    // Generate Weekly icon (blue background) - LEFT position
-    let weeklyIcon;
-    if (weeklyPercent >= 99) {
-      weeklyIcon = generateRedXIcon();
-    } else {
-      const weeklyColor = getBackgroundColor(weeklyPercent, false, warnThreshold, dangerThreshold);
-      weeklyIcon = generatePercentageIcon(weeklyPercent, weeklyColor);
-    }
-    if (weeklyTray && !weeklyTray.isDestroyed()) {
-      weeklyTray.setImage(weeklyIcon);
-      weeklyTray.setToolTip(`Weekly: ${Math.round(weeklyPercent)}%`);
-    }
-    
-    // Generate Session icon (purple background) - RIGHT position
-    let sessionIcon;
+    let icon;
     if (sessionPercent >= 99) {
-      sessionIcon = generateRedXIcon();
+      icon = generateRedXIcon();
     } else {
-      const sessionColor = getBackgroundColor(sessionPercent, true, warnThreshold, dangerThreshold);
-      sessionIcon = generatePercentageIcon(sessionPercent, sessionColor);
+      const color = getBackgroundColor(sessionPercent, true, warnThreshold, dangerThreshold);
+      icon = generatePercentageIcon(sessionPercent, color);
     }
-    if (sessionTray && !sessionTray.isDestroyed()) {
-      sessionTray.setImage(sessionIcon);
-      sessionTray.setToolTip(`Session: ${Math.round(sessionPercent)}%`);
-    }
+    sessionTray.setImage(icon);
+    sessionTray.setToolTip(`Session: ${Math.round(sessionPercent)}%`);
   } catch (error) {
-    console.error('Failed to update tray icons:', error);
+    console.error('Failed to update tray icon:', error);
   }
 }
-
 
 // IPC Handlers
 ipcMain.handle('get-credentials', () => {
   let sessionKey = null;
-  // Try safeStorage first (OS keychain)
   if (safeStorage.isEncryptionAvailable()) {
     const encrypted = store.get('sessionKey_encrypted');
     if (encrypted) {
@@ -676,29 +399,20 @@ ipcMain.handle('get-credentials', () => {
       }
     }
   } else {
-    // Fallback: plain storage (legacy or safeStorage unavailable)
     sessionKey = store.get('sessionKey');
   }
-  return {
-    sessionKey,
-    organizationId: store.get('organizationId')
-  };
+  return { sessionKey, organizationId: store.get('organizationId') };
 });
 
 ipcMain.handle('save-credentials', async (event, { sessionKey, organizationId }) => {
-  // Store session key in OS keychain if available
   if (safeStorage.isEncryptionAvailable()) {
     const encrypted = safeStorage.encryptString(sessionKey);
     store.set('sessionKey_encrypted', encrypted.toString('base64'));
-    store.delete('sessionKey'); // Remove legacy plain storage
+    store.delete('sessionKey');
   } else {
-    // Fallback: plain storage
     store.set('sessionKey', sessionKey);
   }
-  if (organizationId) {
-    store.set('organizationId', organizationId);
-  }
-  // Also set cookie in Electron session for window-based fetching
+  if (organizationId) store.set('organizationId', organizationId);
   await setSessionCookie(sessionKey);
   return true;
 });
@@ -707,13 +421,10 @@ ipcMain.handle('delete-credentials', async () => {
   store.delete('sessionKey');
   store.delete('sessionKey_encrypted');
   store.delete('organizationId');
-  // Remove all Claude.ai cookies
   const cookies = await session.defaultSession.cookies.get({ url: 'https://claude.ai' });
   for (const cookie of cookies) {
     await session.defaultSession.cookies.remove('https://claude.ai', cookie.name);
   }
-  // Clear any cached data from the Electron session (storage, cache)
-  // so nothing lingers on shared machines
   await session.defaultSession.clearStorageData({
     storages: ['localstorage', 'sessionstorage', 'cachestorage'],
     origin: 'https://claude.ai'
@@ -721,102 +432,59 @@ ipcMain.handle('delete-credentials', async () => {
   return true;
 });
 
-// Validate a sessionKey by fetching org ID via hidden BrowserWindow
 ipcMain.handle('validate-session-key', async (event, sessionKey) => {
   debugLog('Validating session key:', sessionKey.substring(0, 20) + '...');
   try {
-    // Set the cookie in Electron's session first
     await setSessionCookie(sessionKey);
-
-    // Fetch organizations using hidden BrowserWindow (bypasses Cloudflare)
     const data = await fetchViaWindow('https://claude.ai/api/organizations');
-
     if (data && Array.isArray(data) && data.length > 0) {
-      // Filter to orgs with 'chat' capability (excludes API-only orgs)
-      const chatOrgs = data.filter(org => 
-        org.capabilities && org.capabilities.includes('chat')
-      );
-
-      if (chatOrgs.length === 0) {
-        return { success: false, error: 'No chat-enabled organizations found' };
-      }
-
-      // Prioritize Teams org if present, otherwise use first chat org
+      const chatOrgs = data.filter(org => org.capabilities && org.capabilities.includes('chat'));
+      if (chatOrgs.length === 0) return { success: false, error: 'No chat-enabled organizations found' };
       const defaultOrg = chatOrgs.find(org => org.raven_type === 'team') || chatOrgs[0];
       const orgId = defaultOrg.uuid || defaultOrg.id;
-      
       debugLog(`Session key validated, found ${chatOrgs.length} chat org(s), default org ID:`, orgId);
-      
-      return { 
-        success: true, 
+      return {
+        success: true,
         organizationId: orgId,
-        organizations: chatOrgs.map(org => ({
-          id: org.uuid || org.id,
-          name: org.name,
-          isTeam: org.raven_type === 'team'
-        }))
+        organizations: chatOrgs.map(org => ({ id: org.uuid || org.id, name: org.name, isTeam: org.raven_type === 'team' }))
       };
     }
-
-    // Check if it's an error response
-    if (data && data.error) {
-      return { success: false, error: data.error.message || data.error };
-    }
-
+    if (data && data.error) return { success: false, error: data.error.message || data.error };
     return { success: false, error: 'No organization found' };
   } catch (error) {
     console.error('Session key validation failed:', error.message);
-    // Clean up the invalid cookie
     await session.defaultSession.cookies.remove('https://claude.ai', 'sessionKey');
     return { success: false, error: error.message };
   }
 });
 
+// Minimize hides the popup — no Dock to minimize to
 ipcMain.on('minimize-window', () => {
-  if (mainWindow) {
-    // macOS: minimize to Dock so the user can restore via Dock click
-    // Windows/Linux: hide to tray (taskbar may be hidden, tray is the restore path)
-    if (process.platform === 'darwin') {
-      mainWindow.minimize();
-    } else {
-      mainWindow.hide();
-    }
-  }
+  if (mainWindow) mainWindow.hide();
 });
 
-ipcMain.on('close-window', () => {
-  app.quit();
-});
+ipcMain.on('close-window', () => { app.quit(); });
 
 ipcMain.on('resize-window', (event, height) => {
-  if (mainWindow) {
-    mainWindow.setContentSize(WIDGET_WIDTH, height);
-  }
+  if (mainWindow) mainWindow.setContentSize(WIDGET_WIDTH, height);
 });
 
 ipcMain.handle('get-window-position', () => {
-  if (mainWindow) {
-    return mainWindow.getBounds();
-  }
+  if (mainWindow) return mainWindow.getBounds();
   return null;
 });
 
 ipcMain.handle('set-window-position', (event, { x, y }) => {
-  if (mainWindow) {
-    mainWindow.setPosition(x, y);
-    return true;
-  }
+  if (mainWindow) { mainWindow.setPosition(x, y); return true; }
   return false;
 });
 
 ipcMain.on('open-external', (event, url) => {
-  // Trust boundary enforcement: duplicate allowlist check in main process
   const allowedDomains = ['claude.ai', 'github.com', 'paypal.me'];
   try {
     const parsedUrl = new URL(url);
-    const isAllowed = allowedDomains.some(domain => 
-      parsedUrl.hostname === domain || parsedUrl.hostname.endsWith('.' + domain)
-    );
+    const isAllowed = allowedDomains.some(domain =>
+      parsedUrl.hostname === domain || parsedUrl.hostname.endsWith('.' + domain));
     if (isAllowed) {
       shell.openExternal(url);
     } else {
@@ -827,19 +495,14 @@ ipcMain.on('open-external', (event, url) => {
   }
 });
 
-ipcMain.handle('get-app-version', () => {
-  return app.getVersion();
-});
+ipcMain.handle('get-app-version', () => app.getVersion());
 
 ipcMain.handle('get-usage-history', () => {
   const history = store.get('usageHistory', []);
   const cutoff = Date.now() - (CHART_DAYS * 24 * 60 * 60 * 1000);
-  return history
-    .filter((entry) => entry.timestamp > cutoff)
-    .sort((a, b) => a.timestamp - b.timestamp);
+  return history.filter((entry) => entry.timestamp > cutoff).sort((a, b) => a.timestamp - b.timestamp);
 });
 
-// Show a native OS desktop notification (Windows toast, macOS NC, Linux libnotify)
 ipcMain.on('show-notification', (event, { title, body }) => {
   if (Notification.isSupported()) {
     const n = new Notification({ title, body, silent: false });
@@ -847,55 +510,48 @@ ipcMain.on('show-notification', (event, { title, body }) => {
   }
 });
 
-// Resize window for compact vs normal mode
-// Compact: 290px wide, normal: 530px wide. Height stays managed by renderer.
 ipcMain.on('set-compact-mode', (event, compact) => {
   if (mainWindow) {
     const bounds = mainWindow.getBounds();
-    const width = compact ? 290 : WIDGET_WIDTH;
+    const width  = compact ? 290 : WIDGET_WIDTH;
     const height = compact ? 105 : WIDGET_HEIGHT;
     mainWindow.setBounds({ x: bounds.x, y: bounds.y, width, height });
   }
 });
 
-// Settings handlers
-ipcMain.handle('get-settings', () => {
-  return {
-    autoStart: store.get('settings.autoStart', false),
-    minimizeToTray: store.get('settings.minimizeToTray', false),
-    alwaysOnTop: store.get('settings.alwaysOnTop', true),
-    theme: store.get('settings.theme', 'dark'),
-    warnThreshold: store.get('settings.warnThreshold', 75),
-    dangerThreshold: store.get('settings.dangerThreshold', 90),
-    timeFormat: store.get('settings.timeFormat', '12h'),
-    weeklyDateFormat: store.get('settings.weeklyDateFormat', 'date'),
-    usageAlerts: store.get('settings.usageAlerts', true),
-    compactMode: store.get('settings.compactMode', false),
-    refreshInterval: store.get('settings.refreshInterval', '300'),
-    graphVisible: store.get('settings.graphVisible', false),
-    expandedOpen: store.get('settings.expandedOpen', false),
-    showTrayStats: store.get('settings.showTrayStats', false)
-  };
-});
+ipcMain.handle('get-settings', () => ({
+  autoStart:        store.get('settings.autoStart', false),
+  minimizeToTray:   store.get('settings.minimizeToTray', false),
+  alwaysOnTop:      store.get('settings.alwaysOnTop', true),
+  theme:            store.get('settings.theme', 'dark'),
+  warnThreshold:    store.get('settings.warnThreshold', 75),
+  dangerThreshold:  store.get('settings.dangerThreshold', 90),
+  timeFormat:       store.get('settings.timeFormat', '12h'),
+  weeklyDateFormat: store.get('settings.weeklyDateFormat', 'date'),
+  usageAlerts:      store.get('settings.usageAlerts', true),
+  compactMode:      store.get('settings.compactMode', false),
+  refreshInterval:  store.get('settings.refreshInterval', '300'),
+  graphVisible:     store.get('settings.graphVisible', false),
+  expandedOpen:     store.get('settings.expandedOpen', false),
+  showTrayStats:    store.get('settings.showTrayStats', false)
+}));
 
 ipcMain.handle('save-settings', (event, settings) => {
-  store.set('settings.autoStart', settings.autoStart);
-  store.set('settings.minimizeToTray', settings.minimizeToTray);
-  store.set('settings.alwaysOnTop', settings.alwaysOnTop);
-  store.set('settings.theme', settings.theme);
-  store.set('settings.warnThreshold', settings.warnThreshold);
-  store.set('settings.dangerThreshold', settings.dangerThreshold);
-  store.set('settings.timeFormat', settings.timeFormat);
+  store.set('settings.autoStart',        settings.autoStart);
+  store.set('settings.minimizeToTray',   settings.minimizeToTray);
+  store.set('settings.alwaysOnTop',      settings.alwaysOnTop);
+  store.set('settings.theme',            settings.theme);
+  store.set('settings.warnThreshold',    settings.warnThreshold);
+  store.set('settings.dangerThreshold',  settings.dangerThreshold);
+  store.set('settings.timeFormat',       settings.timeFormat);
   store.set('settings.weeklyDateFormat', settings.weeklyDateFormat);
-  store.set('settings.usageAlerts', settings.usageAlerts);
-  store.set('settings.compactMode', settings.compactMode);
-  store.set('settings.refreshInterval', settings.refreshInterval);
-  store.set('settings.graphVisible', settings.graphVisible);
-  store.set('settings.expandedOpen', settings.expandedOpen);
-  store.set('settings.showTrayStats', settings.showTrayStats);
+  store.set('settings.usageAlerts',      settings.usageAlerts);
+  store.set('settings.compactMode',      settings.compactMode);
+  store.set('settings.refreshInterval',  settings.refreshInterval);
+  store.set('settings.graphVisible',     settings.graphVisible);
+  store.set('settings.expandedOpen',     settings.expandedOpen);
+  store.set('settings.showTrayStats',    settings.showTrayStats);
 
-  // openAtLogin is not supported on Linux — Electron silently ignores it.
-  // Skip the call entirely to avoid misleading behaviour.
   if (process.platform !== 'linux') {
     app.setLoginItemSettings({
       openAtLogin: settings.autoStart,
@@ -903,75 +559,43 @@ ipcMain.handle('save-settings', (event, settings) => {
     });
   }
 
-  if (mainWindow) {
-    if (process.platform === 'darwin') {
-      if (settings.minimizeToTray) { app.dock.hide(); } else { app.dock.show(); }
-    } else {
-      mainWindow.setSkipTaskbar(settings.minimizeToTray);
-    }
-    mainWindow.setAlwaysOnTop(settings.alwaysOnTop, 'floating');
+  // Dock stays hidden on macOS always (menu bar app)
+  if (mainWindow && process.platform !== 'darwin') {
+    mainWindow.setSkipTaskbar(settings.minimizeToTray);
   }
+  if (mainWindow) mainWindow.setAlwaysOnTop(settings.alwaysOnTop, 'floating');
 
-  // Refresh tray icons immediately with new threshold settings
   const latestUsageData = store.get('latestUsageData');
-  if (latestUsageData) {
-    updateTrayIcon(latestUsageData);
-  }
+  if (latestUsageData) updateTrayIcon(latestUsageData);
 
   return true;
 });
 
-// Open a visible BrowserWindow for the user to log in to Claude.ai.
-//
-// Why we don't embed login directly in the app:
-// Claude.ai (via Cloudflare) detects and blocks Electron-embedded logins.
-// Instead, we open a standalone browser window, let the user authenticate
-// normally, then capture the sessionKey cookie once login completes.
-// Do NOT attempt to "fix" this back to an embedded login without verifying
-// that Claude.ai/Cloudflare no longer blocks it.
-//
-// SECURITY: Navigation is restricted to trusted domains (claude.ai and OAuth
-// providers) to prevent phishing attacks. Popup windows are blocked. Current
-// URL is displayed in the window title bar for transparency.
 ipcMain.handle('detect-session-key', async () => {
-  // Clear any leftover sessionKey cookie
   try {
     await session.defaultSession.cookies.remove('https://claude.ai', 'sessionKey');
-  } catch (e) { /* ignore */ }
+  } catch (e) {}
 
   return new Promise((resolve) => {
     const loginWin = new BrowserWindow({
       width: 1000,
       height: 700,
       title: 'Claude Login - https://claude.ai/login',
-      webPreferences: {
-        nodeIntegration: false,
-        contextIsolation: true
-      }
+      webPreferences: { nodeIntegration: false, contextIsolation: true }
     });
 
     let resolved = false;
-
-    // Security: restrict navigation to trusted domains only
-    const allowedLoginDomains = [
-      'claude.ai',
-      'accounts.google.com',
-      'appleid.apple.com',
-      'login.microsoftonline.com'
-    ];
+    const allowedLoginDomains = ['claude.ai','accounts.google.com','appleid.apple.com','login.microsoftonline.com'];
 
     loginWin.webContents.on('will-navigate', (event, url) => {
       try {
         const hostname = new URL(url).hostname;
-        const isAllowed = allowedLoginDomains.some(domain =>
-          hostname === domain || hostname.endsWith('.' + domain)
-        );
+        const isAllowed = allowedLoginDomains.some(d => hostname === d || hostname.endsWith('.' + d));
         if (!isAllowed) {
           event.preventDefault();
           console.warn('[Security] Blocked login navigation to untrusted domain:', url);
         } else {
-          // Update title bar to show current URL (read-only)
-          loginWin.setTitle(`Claude Login - ${url}`);
+          loginWin.setTitle('Claude Login - ' + url);
         }
       } catch (err) {
         event.preventDefault();
@@ -979,29 +603,15 @@ ipcMain.handle('detect-session-key', async () => {
       }
     });
 
-    // Update title on OAuth redirects and in-page navigation
-    loginWin.webContents.on('did-navigate', (event, url) => {
-      loginWin.setTitle(`Claude Login - ${url}`);
-    });
-
-    loginWin.webContents.on('did-navigate-in-page', (event, url) => {
-      loginWin.setTitle(`Claude Login - ${url}`);
-    });
-
-    // Security: block popup windows from login page
+    loginWin.webContents.on('did-navigate',         (event, url) => loginWin.setTitle('Claude Login - ' + url));
+    loginWin.webContents.on('did-navigate-in-page', (event, url) => loginWin.setTitle('Claude Login - ' + url));
     loginWin.webContents.setWindowOpenHandler(() => {
       console.warn('[Security] Blocked popup window attempt from login page');
       return { action: 'deny' };
     });
 
-    // Listen for sessionKey cookie being set after login
     const onCookieChanged = (event, cookie, cause, removed) => {
-      if (
-        cookie.name === 'sessionKey' &&
-        cookie.domain.includes('claude.ai') &&
-        !removed &&
-        cookie.value
-      ) {
+      if (cookie.name === 'sessionKey' && cookie.domain.includes('claude.ai') && !removed && cookie.value) {
         resolved = true;
         session.defaultSession.cookies.removeListener('changed', onCookieChanged);
         loginWin.close();
@@ -1010,32 +620,24 @@ ipcMain.handle('detect-session-key', async () => {
     };
 
     session.defaultSession.cookies.on('changed', onCookieChanged);
-
     loginWin.on('closed', () => {
       session.defaultSession.cookies.removeListener('changed', onCookieChanged);
-      if (!resolved) {
-        resolve({ success: false, error: 'Login window closed' });
-      }
+      if (!resolved) resolve({ success: false, error: 'Login window closed' });
     });
 
     loginWin.loadURL('https://claude.ai/login');
   });
 });
 
-// Check GitHub releases for a newer version
 ipcMain.handle('check-for-update', () => {
   return new Promise((resolve) => {
     const options = {
       hostname: 'api.github.com',
-      path: `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`,
+      path: '/repos/' + GITHUB_OWNER + '/' + GITHUB_REPO + '/releases/latest',
       method: 'GET',
-      headers: {
-        'User-Agent': 'claude-usage-widget',
-        'Accept': 'application/vnd.github+json'
-      },
+      headers: { 'User-Agent': 'claude-usage-widget', 'Accept': 'application/vnd.github+json' },
       timeout: 5000
     };
-
     const req = https.request(options, (res) => {
       let body = '';
       res.on('data', (chunk) => { body += chunk; });
@@ -1054,7 +656,6 @@ ipcMain.handle('check-for-update', () => {
         }
       });
     });
-
     req.on('error', () => resolve({ hasUpdate: false, version: null }));
     req.on('timeout', () => { req.destroy(); resolve({ hasUpdate: false, version: null }); });
     req.end();
@@ -1063,40 +664,23 @@ ipcMain.handle('check-for-update', () => {
 
 function isNewerVersion(remote, local) {
   try {
-    // Parse version strings with optional pre-release tags
-    // Examples: "1.7.1", "1.7.2-rc.1", "2.0.0-beta.3"
     const parseVersion = (ver) => {
       const [mainVer, preRelease] = ver.split('-');
       const parts = mainVer.split('.').map(Number);
-      return {
-        major: parts[0] || 0,
-        minor: parts[1] || 0,
-        patch: parts[2] || 0,
-        preRelease: preRelease || null
-      };
+      return { major: parts[0] || 0, minor: parts[1] || 0, patch: parts[2] || 0, preRelease: preRelease || null };
     };
-
     const r = parseVersion(remote);
     const l = parseVersion(local);
-
-    // Compare major.minor.patch
     if (r.major !== l.major) return r.major > l.major;
     if (r.minor !== l.minor) return r.minor > l.minor;
     if (r.patch !== l.patch) return r.patch > l.patch;
-
-    // If versions are equal, check pre-release tags
-    // A version WITHOUT pre-release is NEWER than one WITH pre-release
-    // Examples: 1.7.2 > 1.7.2-rc.1, 1.7.2 > 1.7.2-beta.1
-    if (r.preRelease === null && l.preRelease !== null) return true;   // remote is stable, local is pre-release
-    if (r.preRelease !== null && l.preRelease === null) return false;  // remote is pre-release, local is stable
-
-    // Both have same version and both stable (or both pre-release) - not newer
+    if (r.preRelease === null && l.preRelease !== null) return true;
+    if (r.preRelease !== null && l.preRelease === null) return false;
     return false;
   } catch { return false; }
 }
 
 ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
-  // Use the same credential retrieval logic as get-credentials
   let sessionKey = null;
   if (safeStorage.isEncryptionAvailable()) {
     const encrypted = store.get('sessionKey_encrypted');
@@ -1112,64 +696,42 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
   }
 
   const organizationId = store.get('organizationId');
+  if (!sessionKey || !organizationId) throw new Error('Missing credentials');
 
-  if (!sessionKey || !organizationId) {
-    throw new Error('Missing credentials');
-  }
-
-  // Ensure cookie is set
   await setSessionCookie(sessionKey);
 
-  // Conditional API polling: Only fetch overage/prepaid if the expand panel is open
-  // or if compact mode is disabled (normal mode). This reduces API calls when the
-  // user won't see the extra usage data anyway.
-  // If forceExtended is passed (e.g., when user clicks expand), use that instead of saved setting
   const expandedOpen = options.forceExtended !== undefined ? options.forceExtended : store.get('settings.expandedOpen', false);
-  const compactMode = store.get('settings.compactMode', false);
   const shouldFetchExtended = expandedOpen;
 
-  const usageUrl = `https://claude.ai/api/organizations/${organizationId}/usage`;
-  const overageUrl = `https://claude.ai/api/organizations/${organizationId}/overage_spend_limit`;
-  const prepaidUrl = `https://claude.ai/api/organizations/${organizationId}/prepaid/credits`;
+  const usageUrl   = 'https://claude.ai/api/organizations/' + organizationId + '/usage';
+  const overageUrl = 'https://claude.ai/api/organizations/' + organizationId + '/overage_spend_limit';
+  const prepaidUrl = 'https://claude.ai/api/organizations/' + organizationId + '/prepaid/credits';
 
-  // Build URL array based on UI state
   const urls = [usageUrl];
   if (shouldFetchExtended) {
     urls.push(overageUrl, prepaidUrl);
-    debugLog('[Conditional Polling] Fetching extended data (overage + prepaid) - panel is visible');
+    debugLog('[Conditional Polling] Fetching extended data');
   } else {
-    debugLog('[Conditional Polling] Skipping extended data - panel not visible');
+    debugLog('[Conditional Polling] Skipping extended data');
   }
 
-  // Fetch endpoints sequentially using a single reused BrowserWindow.
-  // This reduces memory overhead compared to creating 3 separate windows.
-  // Usage is always required; overage and prepaid are conditional based on UI state.
   let usageResult, overageResult, prepaidResult;
-  
   try {
     const results = await fetchMultipleViaWindow(urls);
-    
-    // Always have usage result (first in array)
     usageResult = { status: 'fulfilled', value: results[0] };
-    
-    // Conditionally map overage/prepaid results
     if (shouldFetchExtended) {
       overageResult = { status: 'fulfilled', value: results[1] };
       prepaidResult = { status: 'fulfilled', value: results[2] };
     } else {
-      // Mark as skipped (not an error, just not fetched)
       overageResult = { status: 'skipped', reason: 'UI panel not visible' };
       prepaidResult = { status: 'skipped', reason: 'UI panel not visible' };
     }
   } catch (error) {
-    // If any fetch fails, determine which one and set appropriate result statuses
-    // For now, if the batch fails, treat usage as failed (required endpoint)
     usageResult = { status: 'rejected', reason: error };
     overageResult = { status: 'rejected', reason: error };
     prepaidResult = { status: 'rejected', reason: error };
   }
 
-  // Usage endpoint is mandatory
   if (usageResult.status === 'rejected') {
     const error = usageResult.reason;
     debugLog('API request failed:', error.message);
@@ -1179,9 +741,7 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
     if (isBlocked) {
       store.delete('sessionKey');
       store.delete('organizationId');
-      if (mainWindow) {
-        mainWindow.webContents.send('session-expired');
-      }
+      if (mainWindow) mainWindow.webContents.send('session-expired');
       throw new Error('SessionExpired');
     }
     throw error;
@@ -1189,63 +749,36 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
 
   const data = usageResult.value;
 
-  // Merge overage spending data into data.extra_usage
   if (overageResult.status === 'fulfilled' && overageResult.value) {
     const overage = overageResult.value;
     const limit = overage.monthly_credit_limit ?? overage.spend_limit_amount_cents;
-    const used = overage.used_credits ?? overage.balance_cents;
+    const used  = overage.used_credits ?? overage.balance_cents;
     const enabled = overage.is_enabled !== undefined ? overage.is_enabled : (limit != null);
-
     if (enabled && typeof limit === 'number' && limit > 0 && typeof used === 'number') {
-      data.extra_usage = {
-        utilization: (used / limit) * 100,
-        resets_at: null,
-        used_cents: used,
-        limit_cents: limit,
-        is_enabled: true,
-        currency: overage.currency || 'USD',
-      };
+      data.extra_usage = { utilization: (used / limit) * 100, resets_at: null, used_cents: used, limit_cents: limit, is_enabled: true, currency: overage.currency || 'USD' };
     } else if (!enabled) {
-      // Extra usage is off — still pass the flag so the renderer can show status
       if (!data.extra_usage) data.extra_usage = {};
       data.extra_usage.is_enabled = false;
       data.extra_usage.currency = overage.currency || 'USD';
     }
-  } else {
-    debugLog('Overage fetch skipped or failed:', overageResult.reason?.message || 'no data');
   }
 
-  // Merge prepaid balance into data.extra_usage
   if (prepaidResult.status === 'fulfilled' && prepaidResult.value) {
     const prepaid = prepaidResult.value;
     if (typeof prepaid.amount === 'number') {
       if (!data.extra_usage) data.extra_usage = {};
       data.extra_usage.balance_cents = prepaid.amount;
-      // Use prepaid currency if overage didn't already set one
-      if (!data.extra_usage.currency && prepaid.currency) {
-        data.extra_usage.currency = prepaid.currency;
-      }
+      if (!data.extra_usage.currency && prepaid.currency) data.extra_usage.currency = prepaid.currency;
     }
-  } else {
-    debugLog('Prepaid fetch skipped or failed:', prepaidResult.reason?.message || 'no data');
   }
 
   storeUsageHistory(data);
-
-  // Store latest usage data for settings refresh
   store.set('latestUsageData', data);
-
-  // Update tray icon with current usage data
   updateTrayIcon(data);
 
-  // Re-assert always-on-top after hidden BrowserWindows from fetchViaWindow
-  // are destroyed — creating/destroying BrowserWindows can temporarily disrupt
-  // the main window's z-order on some OS/window manager combinations.
   if (mainWindow && !mainWindow.isDestroyed()) {
     const alwaysOnTop = store.get('settings.alwaysOnTop', true);
-    if (alwaysOnTop) {
-      mainWindow.setAlwaysOnTop(true, 'floating');
-    }
+    if (alwaysOnTop) mainWindow.setAlwaysOnTop(true, 'floating');
   }
 
   return data;
@@ -1253,7 +786,11 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
 
 // App lifecycle
 app.whenReady().then(async () => {
-  // Restore session cookie if we have stored credentials
+  // Hide from Dock permanently — this is a menu bar app
+  if (process.platform === 'darwin') {
+    app.dock.hide();
+  }
+
   let sessionKey = null;
   if (safeStorage.isEncryptionAvailable()) {
     const encrypted = store.get('sessionKey_encrypted');
@@ -1267,52 +804,30 @@ app.whenReady().then(async () => {
   } else {
     sessionKey = store.get('sessionKey');
   }
-
-  if (sessionKey) {
-    await setSessionCookie(sessionKey);
-  }
+  if (sessionKey) await setSessionCookie(sessionKey);
 
   createMainWindow();
   createTray();
 
-  // Apply persisted settings
-  const minimizeToTray = store.get('settings.minimizeToTray', false);
   const alwaysOnTop = store.get('settings.alwaysOnTop', true);
   if (mainWindow) {
-    if (process.platform === 'darwin') {
-      if (minimizeToTray) app.dock.hide();
-    } else {
+    if (process.platform !== 'darwin') {
+      const minimizeToTray = store.get('settings.minimizeToTray', false);
       if (minimizeToTray) mainWindow.setSkipTaskbar(true);
     }
     mainWindow.setAlwaysOnTop(alwaysOnTop, 'floating');
   }
 
-  // Periodic always-on-top re-assertion to recover from z-order disruptions
-  // (hidden window spawns, window manager shortcuts, alt-tab, etc.)
   setInterval(() => {
     if (mainWindow && !mainWindow.isDestroyed()) {
       const alwaysOnTopSetting = store.get('settings.alwaysOnTop', true);
-      if (alwaysOnTopSetting) {
-        mainWindow.setAlwaysOnTop(true, 'floating');
-      }
+      if (alwaysOnTopSetting) mainWindow.setAlwaysOnTop(true, 'floating');
     }
   }, 5000);
 });
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    // Keep running in tray
-  }
-});
-
-app.on('activate', () => {
-  if (mainWindow === null) {
-    createMainWindow();
-  } else {
-    if (mainWindow.isMinimized()) mainWindow.restore();
-    mainWindow.show();
-    mainWindow.focus();
-  }
+  // Keep running in tray on all platforms
 });
 
 // Prevent multiple instances


### PR DESCRIPTION
Converts the app to a true macOS menu bar app. Changes are isolated to main.js and don't affect Windows or Linux behaviour.

**What changed:**
- `app.dock.hide()` on startup (macOS only) — removes Dock icon and app switcher presence
- `show: false` + `skipTaskbar: true` on BrowserWindow — hidden until needed
- `blur` → `hide` — popup auto-dismisses when you click anywhere else
- Left click toggles the popup, right click shows the context menu
- `positionWindowBelowTray()` anchors the popup directly below the icon
- Single tray icon instead of two — keeps the menu bar clean

**Why:** A floating always-on-top window feels heavy for something you glance at occasionally. This makes it feel native like any other macOS menu bar utility.

Tested on macOS Tahoe 26.4.1, Apple Silicon.