### PR TITLE
fix: clarify Linux startup setting support

### DIFF
--- a/main.js
+++ b/main.js
@@ -879,7 +879,10 @@ ipcMain.handle('get-settings', () => {
 });
 
 ipcMain.handle('save-settings', (event, settings) => {
-  store.set('settings.autoStart', settings.autoStart);
+  const supportsLoginItems = process.platform !== 'linux';
+  const autoStart = supportsLoginItems ? settings.autoStart : false;
+
+  store.set('settings.autoStart', autoStart);
   store.set('settings.minimizeToTray', settings.minimizeToTray);
   store.set('settings.alwaysOnTop', settings.alwaysOnTop);
   store.set('settings.theme', settings.theme);
@@ -896,9 +899,9 @@ ipcMain.handle('save-settings', (event, settings) => {
 
   // openAtLogin is not supported on Linux — Electron silently ignores it.
   // Skip the call entirely to avoid misleading behaviour.
-  if (process.platform !== 'linux') {
+  if (supportsLoginItems) {
     app.setLoginItemSettings({
-      openAtLogin: settings.autoStart,
+      openAtLogin: autoStart,
       ...(process.platform !== 'darwin' && { path: app.getPath('exe') })
     });
   }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -68,7 +68,9 @@ const elements = {
     closeSettingsBtn: document.getElementById('closeSettingsBtn'),
     logoutBtn: document.getElementById('logoutBtn'),
     coffeeBtn: document.getElementById('coffeeBtn'),
+    autoStartCol: document.getElementById('autoStartCol'),
     autoStartToggle: document.getElementById('autoStartToggle'),
+    autoStartHint: document.getElementById('autoStartHint'),
     minimizeToTrayToggle: document.getElementById('minimizeToTrayToggle'),
     alwaysOnTopToggle: document.getElementById('alwaysOnTopToggle'),
     showTrayStatsToggle: document.getElementById('showTrayStatsToggle'),
@@ -1439,8 +1441,16 @@ let dangerThreshold = 90;
 
 async function loadSettings() {
     const settings = await window.electronAPI.getSettings();
+    const isLinux = window.electronAPI.platform === 'linux';
 
-    elements.autoStartToggle.checked = settings.autoStart;
+    elements.autoStartToggle.checked = isLinux ? false : settings.autoStart;
+    elements.autoStartToggle.disabled = isLinux;
+    if (elements.autoStartCol) {
+        elements.autoStartCol.classList.toggle('settings-col-disabled', isLinux);
+    }
+    if (elements.autoStartHint) {
+        elements.autoStartHint.style.display = isLinux ? 'inline' : 'none';
+    }
     elements.minimizeToTrayToggle.checked = settings.minimizeToTray;
     elements.alwaysOnTopToggle.checked = settings.alwaysOnTop;
     elements.showTrayStatsToggle.checked = settings.showTrayStats || false;
@@ -1485,7 +1495,7 @@ async function saveSettings() {
     }
 
     const settings = {
-        autoStart: elements.autoStartToggle.checked,
+        autoStart: window.electronAPI.platform === 'linux' ? false : elements.autoStartToggle.checked,
         minimizeToTray: elements.minimizeToTrayToggle.checked,
         alwaysOnTop: elements.alwaysOnTopToggle.checked,
         showTrayStats: elements.showTrayStatsToggle.checked,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -232,12 +232,13 @@
                     <div class="settings-rows">
                         <!-- Row 1: two toggles -->
                         <div class="settings-row-2col">
-                            <div class="settings-col">
+                            <div class="settings-col" id="autoStartCol">
                                 <span class="settings-row-label">Launch at startup</span>
                                 <label class="toggle-switch">
                                     <input type="checkbox" id="autoStartToggle">
                                     <span class="toggle-slider"></span>
                                 </label>
+                                <span class="settings-row-hint" id="autoStartHint" style="display: none;">Not supported on Linux</span>
                             </div>
                             <div class="settings-col">
                                 <span class="settings-row-label" id="trayLabel">Hide from taskbar</span>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -885,6 +885,17 @@ body.theme-light .settings-disclaimer {
     flex-shrink: 0;
 }
 
+.settings-col-disabled .settings-row-label {
+    color: #787888;
+}
+
+.settings-row-hint {
+    color: #8f8fa0;
+    font-size: 10px;
+    line-height: 1.2;
+    max-width: 78px;
+}
+
 .settings-row-label {
     color: #c0c0c0;
     font-size: 11px;
@@ -989,6 +1000,15 @@ body.theme-light .settings-disclaimer {
 .toggle-switch input:checked + .toggle-slider::before {
     transform: translateX(16px);
     background: #a78bfa;
+}
+
+.toggle-switch input:disabled + .toggle-slider {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.toggle-switch:has(input:disabled) {
+    cursor: not-allowed;
 }
 
 /* Theme Selector */


### PR DESCRIPTION
## Summary

- Disable the "Launch at startup" setting on Linux since it's not doing anything anyway.
- Show an inline Linux hint in the settings panel.
- Normalize saved `autoStart` to `false` on Linux in the main process.

## Testing

- The behaviour tested on a local Linux machine