### PR TITLE
Reduce countdown polling from 1s to 30s (drops idle CPU ~20% → ~1%)

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1051,7 +1051,7 @@ function startCountdown() {
     countdownInterval = setInterval(() => {
         refreshTimers();
         if (isExpanded) refreshExtraTimers();
-    }, 1000);
+    }, 30000);
 }
 
 // Update progress bar


### PR DESCRIPTION
## Summary

Bump the `startCountdown()` polling interval in `src/renderer/app.js` from `1000ms` to `30000ms`. Single-line change.

## Why

The displayed countdown is **minute-precision** — the seconds field in `updateTimer()` is commented out at `src/renderer/app.js:1135`:

```js
const hours = Math.floor(diff / (1000 * 60 * 60));
const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
// const seconds = Math.floor((diff % (1000 * 60)) / 1000); // Optional seconds
```

So polling once per second does **no useful work** — the rendered timer only ever changes once per minute. But each tick still triggers `refreshTimers()` → DOM writes → Electron repaint, so the cost is real.

## What

```diff
function startCountdown() {
    if (countdownInterval) clearInterval(countdownInterval);
    countdownInterval = setInterval(() => {
        refreshTimers();
        if (isExpanded) refreshExtraTimers();
-    }, 1000);
+    }, 30000);
}
```

That's the entire diff.

## Before / after

Measured locally (Linux, AMD Ryzen 9 7945HX, v1.7.4 AppImage extracted + asar-unpacked):

| | idle CPU% (widget process) |
|---|---|
| Before (`1000ms`) | ~20% |
| After (`30000ms`) | ~1% |

No visible UX change — countdown still updates well within its minute-precision granularity (30s worst-case lag on a minute display is invisible).

## Context

I've been re-applying this patch locally on every release (most recently v1.7.3 → v1.7.4 a few days ago) — happy to keep doing that, but figured the upstream win was worth offering. If a 30× drop in polling frequency feels too aggressive, I'd be happy to:

- Make it configurable via a setting, or
- Use a lower value (e.g. 5s or 10s) — anything ≥1s is fine since the display is minute-precision anyway.

Let me know what you'd prefer.

## Platforms tested

- Linux (Ubuntu, AMD Ryzen 9 7945HX, v1.7.4)

The change is platform-agnostic JS, so I'd expect identical behaviour on macOS / Windows, but happy to add screenshots/measurements from another platform if useful.