### PR TITLE
Feature: Multi Account Support

### DIFF
--- a/main.js
+++ b/main.js
@@ -1361,17 +1361,19 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
 
 // ── Multiple accounts ──────────────────────────────────────────────────────
 
-const encryptionAvailable = safeStorage.isEncryptionAvailable();
-
 function encryptKey(key) {
-  if (encryptionAvailable) return safeStorage.encryptString(key).toString('base64');
+  if (safeStorage.isEncryptionAvailable()) return safeStorage.encryptString(key).toString('base64');
   return key;
 }
 
 function decryptKey(enc) {
-  if (encryptionAvailable) {
+  if (!enc) return null;
+  if (safeStorage.isEncryptionAvailable()) {
     try { return safeStorage.decryptString(Buffer.from(enc, 'base64')); }
-    catch { return null; }
+    catch {
+      // Key was stored as plain text (saved before encryption was available) — return as-is
+      return enc;
+    }
   }
   return enc;
 }
@@ -1429,7 +1431,7 @@ ipcMain.handle('switch-account', async (event, id) => {
 
   store.set('activeAccountId', id);
   store.set('organizationId', account.organizationId);
-  if (encryptionAvailable) {
+  if (safeStorage.isEncryptionAvailable()) {
     store.set('sessionKey_encrypted', account.encryptedSessionKey);
     store.delete('sessionKey');
   } else {

--- a/main.js
+++ b/main.js
@@ -1088,9 +1088,17 @@ ipcMain.handle('detect-session-key', async () => {
       loginWin.setTitle(`Claude Login - ${url}`);
     });
 
-    // Security: block popup windows from login page
-    loginWin.webContents.setWindowOpenHandler(() => {
-      console.warn('[Security] Blocked popup window attempt from login page');
+    // Allow OAuth popups (Google, Apple, Microsoft sign-in all open a popup window).
+    // Only allow popups to trusted OAuth provider domains; block everything else.
+    loginWin.webContents.setWindowOpenHandler(({ url }) => {
+      try {
+        const hostname = new URL(url).hostname;
+        const isAllowed = allowedLoginDomains.some(domain =>
+          hostname === domain || hostname.endsWith('.' + domain)
+        );
+        if (isAllowed) return { action: 'allow' };
+      } catch {}
+      console.warn('[Security] Blocked popup window attempt from login page:', url);
       return { action: 'deny' };
     });
 
@@ -1351,6 +1359,125 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
   return data;
 });
 
+// ── Multiple accounts ──────────────────────────────────────────────────────
+
+const encryptionAvailable = safeStorage.isEncryptionAvailable();
+
+function encryptKey(key) {
+  if (encryptionAvailable) return safeStorage.encryptString(key).toString('base64');
+  return key;
+}
+
+function decryptKey(enc) {
+  if (encryptionAvailable) {
+    try { return safeStorage.decryptString(Buffer.from(enc, 'base64')); }
+    catch { return null; }
+  }
+  return enc;
+}
+
+async function clearClaudeCookies() {
+  const cookies = await session.defaultSession.cookies.get({ url: 'https://claude.ai' });
+  for (const c of cookies) await session.defaultSession.cookies.remove('https://claude.ai', c.name);
+}
+
+const ORG_ID_RE = /^[a-f0-9-]{8,36}$/i;
+let fetchAllInFlight = false;
+
+ipcMain.handle('get-accounts', () => {
+  const accounts = store.get('accounts', []);
+  return {
+    accounts: accounts.map(a => ({ id: a.id, label: a.label, organizationId: a.organizationId })),
+    activeAccountId: store.get('activeAccountId', null)
+  };
+});
+
+ipcMain.handle('save-account', async (event, { id, label, sessionKey, organizationId }) => {
+  if (typeof id !== 'string' || !/^[a-zA-Z0-9_-]{1,64}$/.test(id)) return false;
+  if (typeof label !== 'string' || label.length > 100) return false;
+  if (organizationId != null && (typeof organizationId !== 'string' || !ORG_ID_RE.test(organizationId))) return false;
+
+  const accounts = store.get('accounts', []);
+  const idx = accounts.findIndex(a => a.id === id);
+  const encryptedSessionKey = sessionKey ? encryptKey(sessionKey)
+    : (idx >= 0 ? accounts[idx].encryptedSessionKey : null);
+  const account = { id, label, encryptedSessionKey, organizationId };
+  if (idx >= 0) { accounts[idx] = account; } else { accounts.push(account); }
+  store.set('accounts', accounts);
+  return true;
+});
+
+ipcMain.handle('delete-account', async (event, id) => {
+  if (typeof id !== 'string' || !id) return false;
+  const accounts = store.get('accounts', []);
+  if (accounts.length <= 1) return false;
+  store.set('accounts', accounts.filter(a => a.id !== id));
+  if (store.get('activeAccountId') === id) store.delete('activeAccountId');
+  return true;
+});
+
+ipcMain.handle('switch-account', async (event, id) => {
+  if (typeof id !== 'string' || !id) return { success: false, error: 'Invalid id' };
+  const accounts = store.get('accounts', []);
+  const account = accounts.find(a => a.id === id);
+  if (!account) return { success: false, error: 'Account not found' };
+  const sessionKey = decryptKey(account.encryptedSessionKey);
+  if (!sessionKey) return { success: false, error: 'Cannot decrypt session key' };
+
+  await clearClaudeCookies();
+  await setSessionCookie(sessionKey);
+
+  store.set('activeAccountId', id);
+  store.set('organizationId', account.organizationId);
+  if (encryptionAvailable) {
+    store.set('sessionKey_encrypted', account.encryptedSessionKey);
+    store.delete('sessionKey');
+  } else {
+    store.set('sessionKey', sessionKey);
+  }
+  return { success: true, organizationId: account.organizationId };
+});
+
+// Fetch usage data for every saved account sequentially, restoring the active
+// account's session afterwards. Returns { [accountId]: { label, data } | { label, error } }.
+ipcMain.handle('fetch-all-accounts-data', async () => {
+  if (fetchAllInFlight) return {};
+  fetchAllInFlight = true;
+
+  const accounts = store.get('accounts', []);
+  const activeId = store.get('activeAccountId');
+  const results = {};
+
+  try {
+    for (const account of accounts) {
+      const mk = (error) => { results[account.id] = { label: account.label, error }; };
+      const sessionKey = decryptKey(account.encryptedSessionKey);
+      if (!sessionKey) { mk('no key'); continue; }
+      const orgId = account.organizationId;
+      if (!orgId || !ORG_ID_RE.test(orgId)) { mk('invalid org'); continue; }
+
+      await clearClaudeCookies();
+      await setSessionCookie(sessionKey);
+
+      try {
+        const [usageData] = await fetchMultipleViaWindow([`https://claude.ai/api/organizations/${orgId}/usage`]);
+        results[account.id] = { label: account.label, data: usageData };
+      } catch (e) {
+        mk(e.message);
+      }
+    }
+  } finally {
+    const active = accounts.find(a => a.id === activeId);
+    if (active) {
+      const sk = decryptKey(active.encryptedSessionKey);
+      if (sk) { await clearClaudeCookies(); await setSessionCookie(sk); }
+    }
+    fetchAllInFlight = false;
+  }
+
+  return results;
+});
+
 // App lifecycle
 app.whenReady().then(async () => {
   // Restore session cookie if we have stored credentials
@@ -1370,6 +1497,16 @@ app.whenReady().then(async () => {
 
   if (sessionKey) {
     await setSessionCookie(sessionKey);
+
+    // Migrate existing single-account session to the accounts array on first run
+    if (store.get('accounts', []).length === 0 && store.get('organizationId')) {
+      const orgId = store.get('organizationId');
+      if (orgId && sessionKey) {
+        const encryptedSessionKey = store.get('sessionKey_encrypted') || encryptKey(sessionKey);
+        store.set('accounts', [{ id: 'acc_default', label: 'Account 1', encryptedSessionKey, organizationId: orgId }]);
+        store.set('activeAccountId', 'acc_default');
+      }
+    }
   }
 
   createMainWindow();

--- a/main.js
+++ b/main.js
@@ -750,21 +750,10 @@ function updateTrayIcon(usageData) {
 
 // IPC Handlers
 ipcMain.handle('get-credentials', () => {
-  let sessionKey = null;
-  // Try safeStorage first (OS keychain)
-  if (safeStorage.isEncryptionAvailable()) {
-    const encrypted = store.get('sessionKey_encrypted');
-    if (encrypted) {
-      try {
-        sessionKey = safeStorage.decryptString(Buffer.from(encrypted, 'base64'));
-      } catch (err) {
-        console.error('[Keychain] Failed to decrypt session key:', err.message);
-      }
-    }
-  } else {
-    // Fallback: plain storage (legacy or safeStorage unavailable)
-    sessionKey = store.get('sessionKey');
-  }
+  const rawEncrypted = safeStorage.isEncryptionAvailable()
+    ? store.get('sessionKey_encrypted')
+    : null;
+  const sessionKey = rawEncrypted ? decryptKey(rawEncrypted) : store.get('sessionKey');
   return {
     sessionKey,
     organizationId: store.get('organizationId')
@@ -1204,20 +1193,11 @@ function isNewerVersion(remote, local) {
 }
 
 ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
-  // Use the same credential retrieval logic as get-credentials
-  let sessionKey = null;
-  if (safeStorage.isEncryptionAvailable()) {
-    const encrypted = store.get('sessionKey_encrypted');
-    if (encrypted) {
-      try {
-        sessionKey = safeStorage.decryptString(Buffer.from(encrypted, 'base64'));
-      } catch (err) {
-        console.error('[Keychain] Failed to decrypt session key:', err.message);
-      }
-    }
-  } else {
-    sessionKey = store.get('sessionKey');
-  }
+  // Use decryptKey so plain-text keys (saved before encryption was available) still work
+  const rawEncrypted = safeStorage.isEncryptionAvailable()
+    ? store.get('sessionKey_encrypted')
+    : null;
+  const sessionKey = rawEncrypted ? decryptKey(rawEncrypted) : store.get('sessionKey');
 
   const organizationId = store.get('organizationId');
 
@@ -1483,19 +1463,10 @@ ipcMain.handle('fetch-all-accounts-data', async () => {
 // App lifecycle
 app.whenReady().then(async () => {
   // Restore session cookie if we have stored credentials
-  let sessionKey = null;
-  if (safeStorage.isEncryptionAvailable()) {
-    const encrypted = store.get('sessionKey_encrypted');
-    if (encrypted) {
-      try {
-        sessionKey = safeStorage.decryptString(Buffer.from(encrypted, 'base64'));
-      } catch (err) {
-        console.error('[Keychain] Failed to decrypt session key on startup:', err.message);
-      }
-    }
-  } else {
-    sessionKey = store.get('sessionKey');
-  }
+  const rawEncrypted = safeStorage.isEncryptionAvailable()
+    ? store.get('sessionKey_encrypted')
+    : null;
+  const sessionKey = rawEncrypted ? decryptKey(rawEncrypted) : store.get('sessionKey');
 
   if (sessionKey) {
     await setSessionCookie(sessionKey);

--- a/main.js
+++ b/main.js
@@ -1408,12 +1408,12 @@ ipcMain.handle('save-account', async (event, { id, label, sessionKey, organizati
 });
 
 ipcMain.handle('delete-account', async (event, id) => {
-  if (typeof id !== 'string' || !id) return false;
+  if (typeof id !== 'string' || !id) return { ok: false, reason: 'invalid' };
   const accounts = store.get('accounts', []);
-  if (accounts.length <= 1) return false;
+  if (accounts.length <= 1) return { ok: false, reason: 'last' };
+  if (store.get('activeAccountId') === id) return { ok: false, reason: 'active' };
   store.set('accounts', accounts.filter(a => a.id !== id));
-  if (store.get('activeAccountId') === id) store.delete('activeAccountId');
-  return true;
+  return { ok: true };
 });
 
 ipcMain.handle('switch-account', async (event, id) => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "electron .",
     "build": "electron-builder",
     "build:win": "electron-builder --win",
-    "dev": "cross-env NODE_ENV=development electron .",
+    "dev": "cross-env NODE_ENV=development electron . --remote-debugging-port=9223",
     "build:mac": "electron-builder --mac",
     "build:linux": "electron-builder --linux"
   },

--- a/preload.js
+++ b/preload.js
@@ -45,7 +45,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // API
-  fetchUsageData: () => ipcRenderer.invoke('fetch-usage-data'),
+  fetchUsageData: (options) => ipcRenderer.invoke('fetch-usage-data', options),
   getUsageHistory: () => ipcRenderer.invoke('get-usage-history'),
   openExternal: (url) => {
     if (isAllowedExternalUrl(url)) {
@@ -70,5 +70,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   showNotification: (title, body) => ipcRenderer.send('show-notification', { title, body }),
 
   // Compact mode
-  setCompactMode: (compact) => ipcRenderer.send('set-compact-mode', compact)
+  setCompactMode: (compact) => ipcRenderer.send('set-compact-mode', compact),
+
+  // Multiple accounts
+  getAccounts: () => ipcRenderer.invoke('get-accounts'),
+  saveAccount: (data) => ipcRenderer.invoke('save-account', data),
+  deleteAccount: (id) => ipcRenderer.invoke('delete-account', id),
+  switchAccount: (id) => ipcRenderer.invoke('switch-account', id),
+  fetchAllAccountsData: () => ipcRenderer.invoke('fetch-all-accounts-data')
 });

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -230,9 +230,13 @@ function renderAccounts(accounts, activeAccountId) {
             switchBtn.addEventListener('click', async () => {
                 const result = await window.electronAPI.switchAccount(acc.id);
                 if (result.success) {
-                    credentials.organizationId = result.organizationId;
+                    // Refresh full credentials so sessionKey stays in sync with main process
+                    credentials = await window.electronAPI.getCredentials();
                     await loadAccounts();
-                    await fetchUsageData();
+                    // Don't fetch here — settings overlay is open and a fetch can
+                    // trigger resizes or close the overlay on auth errors.
+                    // Data refreshes immediately when settings closes.
+                    window._refreshOnSettingsClose = true;
                 }
             });
             item.appendChild(switchBtn);
@@ -521,6 +525,10 @@ function setupEventListeners() {
         elements.settingsOverlay.style.display = 'none';
         if (!isCompactMode) resizeWidget();
         startAutoUpdate();
+        if (window._refreshOnSettingsClose) {
+            window._refreshOnSettingsClose = false;
+            fetchUsageData();
+        }
     });
 
     elements.logoutBtn.addEventListener('click', async () => {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -195,8 +195,7 @@ async function loadAccounts() {
     const nameEl = document.getElementById('activeAccountName');
     if (nameEl) {
         const active = meta.accounts.find(a => a.id === meta.activeAccountId);
-        nameEl.textContent = active ? active.label : '';
-        nameEl.style.display = multi && active ? 'block' : 'none';
+        nameEl.textContent = multi && active ? active.label : '';
     }
 }
 
@@ -242,6 +241,8 @@ function renderAccounts(accounts, activeAccountId) {
                     // trigger resizes or close the overlay on auth errors.
                     // Data refreshes immediately when settings closes.
                     window._refreshOnSettingsClose = true;
+                } else {
+                    showAccountError('Switch failed — session may have expired');
                 }
             });
             item.appendChild(switchBtn);
@@ -332,7 +333,9 @@ function renderAllAccounts(results, meta) {
         if (result.error) {
             const errEl = document.createElement('div');
             errEl.className = 'multi-account-error';
-            errEl.textContent = 'Unavailable';
+            errEl.textContent = result.error.includes('no key') || result.error.includes('decrypt')
+                ? 'Session key missing'
+                : 'Session expired — switch to re-authenticate';
             block.appendChild(errEl);
         } else {
             const d = result.data;

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -237,6 +237,12 @@ function renderAccounts(accounts, activeAccountId) {
                     // Refresh full credentials so sessionKey stays in sync with main process
                     credentials = await window.electronAPI.getCredentials();
                     await loadAccounts();
+                    // If all-accounts panel is open, re-render it with updated activeAccountId
+                    // so the newly-active account moves out of the panel immediately
+                    if (allAccountsVisible && allAccountsData) {
+                        renderAllAccounts(allAccountsData, window._lastAccountMeta);
+                        resizeWidget();
+                    }
                     // Don't fetch here — settings overlay is open and a fetch can
                     // trigger resizes or close the overlay on auth errors.
                     // Data refreshes immediately when settings closes.

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -10,6 +10,9 @@ let graphVisible = false;
 let graphWasVisible = false; // preserves graph state across compact mode toggle
 let appInitializing = true;  // suppresses _saveViewState during startup restore
 let isFetching = false;       // in-flight guard — prevents overlapping fetchUsageData calls
+let allAccountsVisible = false;
+let allAccountsData = null;
+window._lastAccountMeta = { accounts: [], activeAccountId: null };
 const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const WIDGET_HEIGHT_COLLAPSED = 155;
 const WIDGET_ROW_HEIGHT = 30;
@@ -99,7 +102,19 @@ const elements = {
     compactWeeklyFill: document.getElementById('compactWeeklyFill'),
     compactWeeklyPct: document.getElementById('compactWeeklyPct'),
     compactSettingsOverlay: document.getElementById('compactSettingsOverlay'),
-    closeCompactSettingsBtn: document.getElementById('closeCompactSettingsBtn')
+    closeCompactSettingsBtn: document.getElementById('closeCompactSettingsBtn'),
+
+    // All-accounts view
+    allAccountsBtn: document.getElementById('allAccountsBtn'),
+    multiAccountSection: document.getElementById('multiAccountSection'),
+
+    // Accounts management
+    addAccountBtn: document.getElementById('addAccountBtn'),
+    accountsList: document.getElementById('accountsList'),
+    nameAccountForm: document.getElementById('nameAccountForm'),
+    newAccountLabel: document.getElementById('newAccountLabel'),
+    saveNewAccountBtn: document.getElementById('saveNewAccountBtn'),
+    cancelNewAccountBtn: document.getElementById('cancelNewAccountBtn')
 };
 
 // Populate organization selector dropdown
@@ -130,6 +145,184 @@ function populateOrgSelector(organizations, selectedOrgId) {
     } else {
         // Single org - hide selector column
         elements.orgSelectorCol.style.display = 'none';
+    }
+}
+
+// ── Accounts ─────────────────────────────────────────────────────────────────
+
+function fmtResetTime(iso) {
+    if (!iso) return '—';
+    const diff = new Date(iso) - new Date();
+    if (diff <= 0) return 'resetting';
+    const h = Math.floor(diff / 3600000);
+    const m = Math.floor((diff % 3600000) / 60000);
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function acctBarClass(pct) {
+    return pct >= dangerThreshold ? 'danger' : pct >= warnThreshold ? 'warning' : '';
+}
+
+function resetAddBtn() {
+    if (!elements.addAccountBtn) return;
+    elements.addAccountBtn.disabled = false;
+    elements.addAccountBtn.textContent = '+ Add';
+}
+
+async function loadAccounts() {
+    if (!elements.accountsList) return;
+    const meta = await window.electronAPI.getAccounts();
+    window._lastAccountMeta = meta;
+    renderAccounts(meta.accounts, meta.activeAccountId);
+    if (elements.allAccountsBtn) {
+        elements.allAccountsBtn.style.display = meta.accounts.length > 1 ? 'flex' : 'none';
+    }
+}
+
+function renderAccounts(accounts, activeAccountId) {
+    if (!elements.accountsList) return;
+    elements.accountsList.innerHTML = '';
+    accounts.forEach(acc => {
+        const isActive = acc.id === activeAccountId;
+        const item = document.createElement('div');
+        item.className = 'account-item' + (isActive ? ' active' : '');
+
+        const dot = document.createElement('span');
+        dot.className = 'account-dot';
+        const labelEl = document.createElement('span');
+        labelEl.className = 'account-label';
+        labelEl.title = acc.label;
+        labelEl.textContent = acc.label;
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'account-delete-btn';
+        deleteBtn.title = 'Remove';
+        deleteBtn.textContent = '×';
+
+        item.appendChild(dot);
+        item.appendChild(labelEl);
+
+        if (isActive) {
+            const badge = document.createElement('span');
+            badge.className = 'account-active-badge';
+            badge.textContent = 'active';
+            item.appendChild(badge);
+        } else {
+            const switchBtn = document.createElement('button');
+            switchBtn.className = 'account-switch-btn';
+            switchBtn.dataset.id = acc.id;
+            switchBtn.textContent = 'Switch';
+            switchBtn.addEventListener('click', async () => {
+                const result = await window.electronAPI.switchAccount(acc.id);
+                if (result.success) {
+                    credentials.organizationId = result.organizationId;
+                    await loadAccounts();
+                    await fetchUsageData();
+                }
+            });
+            item.appendChild(switchBtn);
+        }
+
+        item.appendChild(deleteBtn);
+        deleteBtn.addEventListener('click', async (e) => {
+            e.stopPropagation();
+            await window.electronAPI.deleteAccount(acc.id);
+            await loadAccounts();
+        });
+
+        elements.accountsList.appendChild(item);
+    });
+}
+
+// ── All-accounts view ────────────────────────────────────────────────────────
+
+async function refreshAllAccountsData() {
+    if (!allAccountsVisible || !elements.multiAccountSection) return;
+    try {
+        const [data, meta] = await Promise.all([
+            window.electronAPI.fetchAllAccountsData(),
+            window.electronAPI.getAccounts()
+        ]);
+        allAccountsData = data;
+        window._lastAccountMeta = meta;
+        renderAllAccounts(data, meta);
+    } catch (e) {
+        console.warn('[accounts] refresh failed, keeping previous data', e);
+    }
+    resizeWidget();
+}
+
+async function toggleAllAccounts() {
+    if (!elements.multiAccountSection) return;
+    allAccountsVisible = !allAccountsVisible;
+    elements.allAccountsBtn.classList.toggle('active', allAccountsVisible);
+
+    if (!allAccountsVisible) {
+        elements.multiAccountSection.style.display = 'none';
+        resizeWidget();
+        return;
+    }
+
+    elements.multiAccountSection.innerHTML = '<div class="multi-account-loading">Fetching all accounts…</div>';
+    elements.multiAccountSection.style.display = 'block';
+    resizeWidget();
+
+    try {
+        const [data, meta] = await Promise.all([
+            window.electronAPI.fetchAllAccountsData(),
+            window.electronAPI.getAccounts()
+        ]);
+        allAccountsData = data;
+        window._lastAccountMeta = meta;
+        renderAllAccounts(data, meta);
+    } catch (e) {
+        elements.multiAccountSection.innerHTML = '<div class="multi-account-loading">Failed to load</div>';
+    }
+    resizeWidget();
+}
+
+function renderAllAccounts(results, meta) {
+    if (!elements.multiAccountSection) return;
+    const { activeAccountId } = meta || window._lastAccountMeta;
+
+    elements.multiAccountSection.innerHTML = '';
+
+    for (const [id, result] of Object.entries(results)) {
+        if (id === activeAccountId) continue;
+        const block = document.createElement('div');
+        block.className = 'multi-account-block';
+
+        const labelEl = document.createElement('div');
+        labelEl.className = 'multi-account-label';
+        labelEl.textContent = result.label;
+        block.appendChild(labelEl);
+
+        if (result.error) {
+            const errEl = document.createElement('div');
+            errEl.className = 'multi-account-error';
+            errEl.textContent = 'Unavailable';
+            block.appendChild(errEl);
+        } else {
+            const d = result.data;
+            const sessionPct = Math.min(Math.round(d?.five_hour?.utilization || 0), 100);
+            const weeklyPct  = Math.min(Math.round(d?.seven_day?.utilization || 0), 100);
+
+            const makeRow = (rowLabel, pct, resetsAt, extraClass) => {
+                const row = document.createElement('div');
+                row.className = 'multi-account-row';
+                row.innerHTML = `
+                    <span class="multi-account-row-label">${rowLabel}</span>
+                    <div class="multi-account-bar-bg">
+                        <div class="multi-account-bar-fill${extraClass ? ' ' + extraClass : ''} ${acctBarClass(pct)}" style="width:${pct}%"></div>
+                    </div>
+                    <span class="multi-account-pct">${pct}%</span>
+                    <span class="multi-account-time">${fmtResetTime(resetsAt)}</span>`;
+                return row;
+            };
+
+            block.appendChild(makeRow('Session', sessionPct, d?.five_hour?.resets_at, ''));
+            block.appendChild(makeRow('Weekly',  weeklyPct,  d?.seven_day?.resets_at,  'weekly'));
+        }
+        elements.multiAccountSection.appendChild(block);
     }
 }
 
@@ -195,6 +388,7 @@ async function init() {
         showMainContent();
         await fetchUsageData();
         startAutoUpdate();
+        loadAccounts();
     } else {
         showLoginRequired();
     }
@@ -247,6 +441,7 @@ function setupEventListeners() {
         debugLog('Refresh button clicked');
         elements.refreshBtn.classList.add('spinning');
         await fetchUsageData();
+        if (allAccountsVisible) await refreshAllAccountsData();
         elements.refreshBtn.classList.remove('spinning');
     });
 
@@ -395,10 +590,58 @@ function setupEventListeners() {
             elements.compactSettingsOverlay.style.display = 'flex';
         } else {
             await loadSettings();
+            await loadAccounts();
             elements.settingsOverlay.style.display = 'flex';
-            window.electronAPI.resizeWindow(318); // Increased from 288 for org selector row
+            window.electronAPI.resizeWindow(440); // settings + accounts section
         }
     });
+
+    // ── All-accounts toggle ───────────────────────────────────────────────────
+    if (elements.allAccountsBtn) {
+        elements.allAccountsBtn.addEventListener('click', toggleAllAccounts);
+    }
+
+    // ── Accounts ──────────────────────────────────────────────────────────────
+    let pendingNewAccount = null;
+
+    if (elements.addAccountBtn) {
+        elements.addAccountBtn.addEventListener('click', async () => {
+            elements.addAccountBtn.disabled = true;
+            elements.addAccountBtn.textContent = 'Logging in…';
+            try {
+                const result = await window.electronAPI.detectSessionKey();
+                if (!result.success) { resetAddBtn(); return; }
+                const validation = await window.electronAPI.validateSessionKey(result.sessionKey);
+                if (!validation.success) { resetAddBtn(); return; }
+                pendingNewAccount = { sessionKey: result.sessionKey, organizationId: validation.organizationId };
+                elements.newAccountLabel.value = '';
+                elements.nameAccountForm.style.display = 'flex';
+                resetAddBtn();
+                elements.newAccountLabel.focus();
+            } catch (e) {
+                resetAddBtn();
+            }
+        });
+    }
+
+    if (elements.saveNewAccountBtn) {
+        elements.saveNewAccountBtn.addEventListener('click', async () => {
+            if (!pendingNewAccount) return;
+            const label = elements.newAccountLabel.value.trim() || 'Account';
+            const id = 'acc_' + Date.now();
+            await window.electronAPI.saveAccount({ id, label, sessionKey: pendingNewAccount.sessionKey, organizationId: pendingNewAccount.organizationId });
+            pendingNewAccount = null;
+            elements.nameAccountForm.style.display = 'none';
+            await loadAccounts();
+        });
+    }
+
+    if (elements.cancelNewAccountBtn) {
+        elements.cancelNewAccountBtn.addEventListener('click', () => {
+            pendingNewAccount = null;
+            elements.nameAccountForm.style.display = 'none';
+        });
+    }
 
     // Close compact settings — apply compact toggle value then close
     elements.closeCompactSettingsBtn.addEventListener('click', async () => {
@@ -742,7 +985,11 @@ function resizeWidget(bannerVisible) {
         ? EXPAND_OVERHEAD + (extraCount * WIDGET_ROW_HEIGHT)
         : 0;
     const graphOffset = graphVisible ? GRAPH_HEIGHT : 0;
-    const totalHeight = WIDGET_HEIGHT_COLLAPSED + expandedOffset + graphOffset + bannerOffset;
+    const multiAcctBlocks = elements.multiAccountSection
+        ? elements.multiAccountSection.querySelectorAll('.multi-account-block').length : 0;
+    const multiAcctOffset = allAccountsVisible
+        ? (multiAcctBlocks > 0 ? multiAcctBlocks * 72 + 12 : 28) : 0;
+    const totalHeight = WIDGET_HEIGHT_COLLAPSED + expandedOffset + graphOffset + bannerOffset + multiAcctOffset;
     window.electronAPI.resizeWindow(totalHeight);
 }
 
@@ -1224,6 +1471,7 @@ function startAutoUpdate() {
     updateInterval = setInterval(async () => {
         if (elements.refreshBtn) elements.refreshBtn.classList.add('spinning');
         await fetchUsageData();
+        if (allAccountsVisible) await refreshAllAccountsData();
         if (elements.refreshBtn) elements.refreshBtn.classList.remove('spinning');
     }, intervalSecs * 1000);
 }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -190,8 +190,13 @@ async function loadAccounts() {
     const meta = await window.electronAPI.getAccounts();
     window._lastAccountMeta = meta;
     renderAccounts(meta.accounts, meta.activeAccountId);
-    if (elements.allAccountsBtn) {
-        elements.allAccountsBtn.style.display = meta.accounts.length > 1 ? 'flex' : 'none';
+    const multi = meta.accounts.length > 1;
+    if (elements.allAccountsBtn) elements.allAccountsBtn.style.display = multi ? 'flex' : 'none';
+    const nameEl = document.getElementById('activeAccountName');
+    if (nameEl) {
+        const active = meta.accounts.find(a => a.id === meta.activeAccountId);
+        nameEl.textContent = active ? active.label : '';
+        nameEl.style.display = multi && active ? 'block' : 'none';
     }
 }
 

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -169,6 +169,22 @@ function resetAddBtn() {
     elements.addAccountBtn.textContent = '+ Add';
 }
 
+let _acctErrTimer = null;
+function showAccountError(msg) {
+    if (!elements.accountsList) return;
+    let err = document.getElementById('accountsError');
+    if (!err) {
+        err = document.createElement('div');
+        err.id = 'accountsError';
+        err.className = 'accounts-error';
+        elements.accountsList.parentNode.insertBefore(err, elements.accountsList.nextSibling);
+    }
+    err.textContent = msg;
+    err.style.display = 'block';
+    clearTimeout(_acctErrTimer);
+    _acctErrTimer = setTimeout(() => { err.style.display = 'none'; }, 3000);
+}
+
 async function loadAccounts() {
     if (!elements.accountsList) return;
     const meta = await window.electronAPI.getAccounts();
@@ -222,12 +238,20 @@ function renderAccounts(accounts, activeAccountId) {
             item.appendChild(switchBtn);
         }
 
-        item.appendChild(deleteBtn);
-        deleteBtn.addEventListener('click', async (e) => {
-            e.stopPropagation();
-            await window.electronAPI.deleteAccount(acc.id);
-            await loadAccounts();
-        });
+        if (!isActive) {
+            item.appendChild(deleteBtn);
+            deleteBtn.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                const result = await window.electronAPI.deleteAccount(acc.id);
+                if (result.ok) {
+                    await loadAccounts();
+                } else {
+                    showAccountError(result.reason === 'last'
+                        ? "Can't delete your only account"
+                        : "Can't delete this account");
+                }
+            });
+        }
 
         elements.accountsList.appendChild(item);
     });

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -976,6 +976,7 @@ const BANNER_HEIGHT = 28;
 const EXPAND_OVERHEAD = 28; // margin-top(12) + padding-top(6) + bottom buffer(10)
 
 function resizeWidget(bannerVisible) {
+    if (elements.settingsOverlay && elements.settingsOverlay.style.display !== 'none') return;
     const hasBanner = bannerVisible !== undefined
         ? bannerVisible
         : elements.updateBanner.style.display !== 'none';

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -541,7 +541,8 @@ function setupEventListeners() {
         startAutoUpdate();
         if (window._refreshOnSettingsClose) {
             window._refreshOnSettingsClose = false;
-            fetchUsageData();
+            await fetchUsageData();
+            if (allAccountsVisible) refreshAllAccountsData();
         }
     });
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -136,6 +136,9 @@
                     <span class="col-header col-header-center">Resets At</span>
                 </div>
 
+                <!-- Active account name (shown only when 2+ accounts saved) -->
+                <div id="activeAccountName" class="active-account-name" style="display:none;"></div>
+
                 <!-- Session Usage -->
                 <div class="usage-section">
                     <span class="usage-label">Current Session</span>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -129,15 +129,12 @@
 
                 <!-- Column Headers -->
                 <div class="usage-headers">
-                    <span></span>
+                    <span id="activeAccountName" class="active-account-name"></span>
                     <span class="col-header col-header-center">Session Used</span>
                     <span class="col-header col-header-center">Elapsed</span>
                     <span class="col-header col-header-center">Resets In</span>
                     <span class="col-header col-header-center">Resets At</span>
                 </div>
-
-                <!-- Active account name (shown only when 2+ accounts saved) -->
-                <div id="activeAccountName" class="active-account-name" style="display:none;"></div>
 
                 <!-- Session Usage -->
                 <div class="usage-section">

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -27,6 +27,12 @@
                     <span>Claude Usage</span>
                 </div>
                 <div class="controls">
+                    <button class="control-btn all-accounts-btn" id="allAccountsBtn" title="Show all accounts" style="display:none;">
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="9" cy="7" r="4"/><path d="M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2"/>
+                            <path d="M16 3.13a4 4 0 0 1 0 7.75"/><path d="M21 21v-2a4 4 0 0 0-3-3.87"/>
+                        </svg>
+                    </button>
                     <button class="control-btn settings-btn" id="settingsBtn" title="Settings">⚙️</button>
                     <button class="control-btn refresh-btn" id="refreshBtn" title="Refresh">
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
@@ -186,6 +192,8 @@
                     <canvas id="usageChart"></canvas>
                 </div>
 
+                <!-- Multi-account section: shown when "all accounts" is toggled -->
+                <div id="multiAccountSection" style="display:none;"></div>
 
             </div>
 
@@ -360,6 +368,20 @@
                             <div class="settings-col">
                                 <!-- placeholder -->
                             </div>
+                        </div>
+                    </div>
+
+                    <!-- Accounts section -->
+                    <div class="accounts-section">
+                        <div class="accounts-header">
+                            <span class="accounts-title">Accounts</span>
+                            <button class="add-account-btn" id="addAccountBtn">+ Add</button>
+                        </div>
+                        <div id="accountsList" class="accounts-list"></div>
+                        <div id="nameAccountForm" class="name-account-form" style="display:none;">
+                            <input type="text" id="newAccountLabel" class="account-label-input" placeholder="Label (e.g. Work)" maxlength="30">
+                            <button id="saveNewAccountBtn" class="save-account-btn">Save</button>
+                            <button id="cancelNewAccountBtn" class="cancel-account-btn">Cancel</button>
                         </div>
                     </div>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -779,6 +779,7 @@ body.theme-light .graph-btn.active {
     flex-direction: column;
     height: 100%;
     padding: 0;
+    overflow-y: auto;
 }
 
 .settings-overlay {
@@ -848,9 +849,9 @@ body.theme-light .settings-disclaimer {
     flex: 1;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     padding: 6px 14px;
-    gap: 10px;
+    gap: 8px;
 }
 
 .settings-row {
@@ -1521,3 +1522,118 @@ body.theme-light .compact-pct {
 .progress-fill.pulse {
     animation: pulse-danger 1.2s ease-in-out infinite;
 }
+
+/* ── All-accounts button ───────────────────────────────────── */
+.all-accounts-btn { opacity: 0.5; }
+.all-accounts-btn.active { opacity: 1; color: #60a5fa; }
+.all-accounts-btn svg { display: block; }
+
+/* ── Multi-account section ─────────────────────────────────── */
+#multiAccountSection {
+    border-top: 1px solid rgba(255,255,255,0.07);
+    padding: 6px 12px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.multi-account-block { display: flex; flex-direction: column; gap: 3px; }
+.multi-account-label {
+    font-size: 10px; font-weight: 600; color: #8080a0;
+    text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 1px;
+}
+.multi-account-row {
+    display: grid;
+    grid-template-columns: 48px 1fr 32px 42px;
+    align-items: center; gap: 6px; height: 20px;
+}
+.multi-account-row-label { font-size: 10px; color: #707080; text-align: right; }
+.multi-account-bar-bg {
+    height: 10px; background: rgba(255,255,255,0.08); border-radius: 4px; overflow: hidden;
+}
+.multi-account-bar-fill {
+    height: 100%; background: linear-gradient(90deg, #8b5cf6 0%, #a78bfa 100%);
+    border-radius: 4px; transition: width 0.5s ease;
+}
+.multi-account-bar-fill.weekly { background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%); }
+.multi-account-bar-fill.warning { background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%); }
+.multi-account-bar-fill.danger  { background: linear-gradient(90deg, #ef4444 0%, #f87171 100%); }
+.multi-account-pct  { font-size: 10px; font-weight: 700; color: #c0c0d8; text-align: right; font-variant-numeric: tabular-nums; }
+.multi-account-time { font-size: 10px; color: #707080; text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.multi-account-loading { font-size: 11px; color: #6060a0; padding: 6px 0; text-align: center; }
+.multi-account-error { font-size: 10px; color: #ef4444; padding: 2px 0; }
+
+body.theme-light #multiAccountSection { border-top-color: rgba(0,0,0,0.08); }
+body.theme-light .multi-account-label  { color: #a0a0c0; }
+body.theme-light .multi-account-row-label { color: #909090; }
+body.theme-light .multi-account-bar-bg { background: rgba(0,0,0,0.08); }
+body.theme-light .multi-account-pct   { color: #303050; }
+body.theme-light .multi-account-time  { color: #909090; }
+
+/* ── Accounts section (settings panel) ────────────────────── */
+.accounts-section {
+    padding: 8px 14px 0;
+    border-top: 1px solid rgba(255,255,255,0.06);
+}
+.accounts-header {
+    display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px;
+}
+.accounts-title {
+    font-size: 11px; font-weight: 600; color: #8080a0;
+    text-transform: uppercase; letter-spacing: 0.5px;
+}
+.add-account-btn {
+    background: rgba(139,92,246,0.15); border: 1px solid rgba(139,92,246,0.35);
+    border-radius: 5px; color: #a78bfa; font-size: 10px; font-weight: 600;
+    padding: 3px 8px; cursor: pointer; transition: background 0.15s;
+}
+.add-account-btn:hover { background: rgba(139,92,246,0.28); }
+.add-account-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.accounts-list {
+    display: flex; flex-direction: column; gap: 4px; max-height: 80px; overflow-y: auto;
+}
+.account-item {
+    display: flex; align-items: center; gap: 6px; padding: 4px 6px;
+    border-radius: 5px; background: rgba(255,255,255,0.04); border: 1px solid transparent;
+}
+.account-item.active { border-color: rgba(139,92,246,0.35); background: rgba(139,92,246,0.1); }
+.account-dot { width: 6px; height: 6px; border-radius: 50%; background: rgba(255,255,255,0.2); flex-shrink: 0; }
+.account-item.active .account-dot { background: #a78bfa; }
+.account-label { flex: 1; font-size: 11px; color: #c0c0d8; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.account-item.active .account-label { color: #e0e0f8; font-weight: 600; }
+.account-active-badge { font-size: 9px; color: #a78bfa; font-weight: 700; white-space: nowrap; }
+.account-switch-btn {
+    background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 4px; color: #9090b0; font-size: 9px; padding: 2px 5px;
+    cursor: pointer; white-space: nowrap; transition: background 0.15s;
+}
+.account-switch-btn:hover { background: rgba(139,92,246,0.2); color: #a78bfa; }
+.account-delete-btn {
+    background: transparent; border: none; color: #606070; font-size: 13px;
+    cursor: pointer; padding: 0 2px; line-height: 1; transition: color 0.15s; flex-shrink: 0;
+}
+.account-delete-btn:hover { color: #ef4444; }
+.name-account-form { display: flex; align-items: center; gap: 5px; padding: 6px 0 4px; }
+.account-label-input {
+    flex: 1; background: rgba(255,255,255,0.08); border: 1px solid rgba(139,92,246,0.4);
+    border-radius: 5px; color: #e0e0f0; font-size: 11px; padding: 4px 7px;
+    outline: none; font-family: inherit;
+}
+.save-account-btn {
+    background: rgba(139,92,246,0.2); border: 1px solid rgba(139,92,246,0.4);
+    border-radius: 5px; color: #c4b5fd; font-size: 10px; font-weight: 600;
+    padding: 4px 8px; cursor: pointer;
+}
+.save-account-btn:hover { background: rgba(139,92,246,0.35); }
+.cancel-account-btn {
+    background: transparent; border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 5px; color: #808090; font-size: 10px; padding: 4px 6px; cursor: pointer;
+}
+.cancel-account-btn:hover { color: #a0a0b0; }
+
+body.theme-light .accounts-section { border-top-color: rgba(0,0,0,0.08); }
+body.theme-light .accounts-title { color: #a0a0c0; }
+body.theme-light .account-item { background: rgba(0,0,0,0.03); }
+body.theme-light .account-item.active { background: rgba(139,92,246,0.07); border-color: rgba(139,92,246,0.25); }
+body.theme-light .account-label { color: #404060; }
+body.theme-light .account-item.active .account-label { color: #1a1a2e; }
+body.theme-light .account-label-input { background: rgba(0,0,0,0.05); border-color: rgba(139,92,246,0.35); color: #303050; }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1523,6 +1523,17 @@ body.theme-light .compact-pct {
     animation: pulse-danger 1.2s ease-in-out infinite;
 }
 
+/* ── Active account name (main widget, multi-account only) ── */
+.active-account-name {
+    font-size: 9px;
+    font-weight: 600;
+    color: #a78bfa;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    padding: 4px 12px 0;
+}
+body.theme-light .active-account-name { color: #7c3aed; }
+
 /* ── All-accounts button ───────────────────────────────────── */
 .all-accounts-btn { opacity: 0.5; }
 .all-accounts-btn.active { opacity: 1; color: #60a5fa; }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1530,7 +1530,9 @@ body.theme-light .compact-pct {
     color: #a78bfa;
     text-transform: uppercase;
     letter-spacing: 0.6px;
-    padding: 4px 12px 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 body.theme-light .active-account-name { color: #7c3aed; }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1612,6 +1612,11 @@ body.theme-light .multi-account-time  { color: #909090; }
     cursor: pointer; padding: 0 2px; line-height: 1; transition: color 0.15s; flex-shrink: 0;
 }
 .account-delete-btn:hover { color: #ef4444; }
+.accounts-error {
+    font-size: 10px; color: #ef4444; padding: 4px 0 2px;
+}
+body.theme-light .accounts-error { color: #dc2626; }
+
 .name-account-form { display: flex; align-items: center; gap: 5px; padding: 6px 0 4px; }
 .account-label-input {
     flex: 1; background: rgba(255,255,255,0.08); border: 1px solid rgba(139,92,246,0.4);

--- a/test-widget.ps1
+++ b/test-widget.ps1
@@ -1,0 +1,227 @@
+# Widget stress test via browser-harness CDP
+# Start the widget first:  npm run dev  (in another terminal)
+# Then run:                .\test-widget.ps1
+#
+# BU_CDP_URL is set only for this script's process and cleaned up at the end.
+# It does NOT affect other terminals or your Chrome browser-harness usage.
+
+$env:PATH = "$env:USERPROFILE\.local\bin;" + $env:PATH
+$_old_cdp = $env:BU_CDP_URL          # save whatever was set before
+$env:BU_CDP_URL = "http://127.0.0.1:9223"
+
+try {
+    $tcp = New-Object System.Net.Sockets.TcpClient
+    $tcp.Connect("127.0.0.1", 9223)
+    $tcp.Close()
+    Write-Host "[ok] Electron debug port open" -ForegroundColor Green
+} catch {
+    Write-Host "[FAIL] Port 9223 not open. Run 'npm run dev' first." -ForegroundColor Red
+    $env:BU_CDP_URL = $_old_cdp
+    exit 1
+}
+
+$pass = 0; $fail = 0
+
+function bh($code) {
+    $out = $code | browser-harness 2>&1
+    Write-Host ($out -join "`n")
+    return $out
+}
+
+function Check($name, $passed, $msg) {
+    if ($passed) {
+        Write-Host "  PASS: $name" -ForegroundColor Green
+        $script:pass++
+    } else {
+        Write-Host "  FAIL: $name — $msg" -ForegroundColor Red
+        $script:fail++
+    }
+}
+
+# ── shared helpers injected into every bh() call ─────────────────────────────
+$H = @"
+import time, json, os
+
+WIDGET_DIR = r"$PSScriptRoot"
+
+def widget_state():
+    return js('''({
+        sessionPct:   document.getElementById("sessionPercentage")?.textContent?.trim(),
+        weeklyPct:    document.getElementById("weeklyPercentage")?.textContent?.trim(),
+        sessionTime:  document.getElementById("sessionTimeText")?.textContent?.trim(),
+        accountName:  document.getElementById("activeAccountName")?.textContent?.trim(),
+        settingsOpen: document.getElementById("settingsOverlay")?.style.display !== "none",
+        allAccBtn:    document.getElementById("allAccountsBtn")?.style.display,
+        multiSection: document.getElementById("multiAccountSection")?.style.display,
+        loginVisible: document.getElementById("loginContainer")?.style.display !== "none",
+        accountItems: Array.from(document.querySelectorAll(".account-item")).map(el => ({
+            label:  el.querySelector(".account-label")?.textContent?.trim(),
+            active: el.classList.contains("active"),
+        })),
+    })''')
+
+def screenshot(name):
+    try:
+        path = capture_screenshot(os.path.join(WIDGET_DIR, f"test-{name}.png"))
+        print(f"  saved {name}.png")
+    except Exception as e:
+        print(f"  screenshot skipped: {e}")
+
+def btn_pos(selector):
+    return js(f'''(function(){{
+        var el = document.querySelector("{selector}");
+        if (!el) return null;
+        var b = el.getBoundingClientRect();
+        return {{x: b.left+b.width/2, y: b.top+b.height/2, visible: b.width>0}};
+    }})()''')
+
+def close_settings_if_open():
+    state = widget_state()
+    if state["settingsOpen"]:
+        b = btn_pos("#closeSettingsBtn")
+        if b and b["visible"]:
+            click_at_xy(b["x"], b["y"])
+            time.sleep(0.6)
+
+"@
+
+# ── TEST 1: baseline ──────────────────────────────────────────────────────────
+Write-Host "`n=== TEST 1: Baseline ===" -ForegroundColor Cyan
+$out = bh ($H + @"
+close_settings_if_open()
+state = widget_state()
+print(json.dumps(state, indent=2))
+screenshot("1-baseline")
+print("RESULT_loginVisible=" + str(state["loginVisible"]))
+print("RESULT_sessionPct=" + str(state["sessionPct"]))
+"@)
+Check "not on login screen" (-not ($out -match "RESULT_loginVisible=True")) "login screen is showing"
+Check "session data present"  ($out -match 'RESULT_sessionPct=\d') "sessionPct missing or zero"
+
+# ── TEST 2: settings opens, accounts listed ───────────────────────────────────
+Write-Host "`n=== TEST 2: Settings + accounts ===" -ForegroundColor Cyan
+$out = bh ($H + @"
+close_settings_if_open()
+b = btn_pos("#settingsBtn")
+click_at_xy(b["x"], b["y"])
+time.sleep(1.0)
+state = widget_state()
+screenshot("2-settings-open")
+print("RESULT_settingsOpen=" + str(state["settingsOpen"]))
+print("RESULT_accountCount=" + str(len(state["accountItems"])))
+for a in state["accountItems"]:
+    print(f"  account: {a['label']} active={a['active']}")
+"@)
+Check "settings opened"    ($out -match "RESULT_settingsOpen=True") "settings did not open"
+Check "accounts listed"    ($out -match "RESULT_accountCount=[1-9]") "no accounts in list"
+
+# ── TEST 3: switch account ────────────────────────────────────────────────────
+Write-Host "`n=== TEST 3: Switch account ===" -ForegroundColor Cyan
+$out = bh ($H + @"
+# Ensure settings is open (may have been left open from test 2)
+state = widget_state()
+if not state["settingsOpen"]:
+    b = btn_pos("#settingsBtn")
+    click_at_xy(b["x"], b["y"])
+    time.sleep(1.0)
+
+switch_btn = btn_pos(".account-switch-btn")
+if not switch_btn or not switch_btn["visible"]:
+    print("RESULT_skipped=only_one_account")
+else:
+    before_name = widget_state()["accountName"]
+    print(f"Switching away from: {before_name}")
+    click_at_xy(switch_btn["x"], switch_btn["y"])
+    time.sleep(1.5)
+    screenshot("3-settings-after-switch")
+
+    # Close settings — this triggers fetchUsageData + refreshAllAccountsData
+    close_settings_if_open()
+    time.sleep(4.0)   # wait for fetch to complete
+
+    state = widget_state()
+    screenshot("3-main-after-switch")
+    print(f"After switch: accountName={state['accountName']} session={state['sessionPct']} time={state['sessionTime']}")
+    print("RESULT_loginVisible=" + str(state["loginVisible"]))
+    print("RESULT_sessionPct=" + str(state["sessionPct"]))
+    print("RESULT_sessionTime=" + str(state["sessionTime"]))
+"@)
+if ($out -match "RESULT_skipped") {
+    Write-Host "  SKIP: only one account saved" -ForegroundColor Yellow
+} else {
+    Check "no login screen after switch" (-not ($out -match "RESULT_loginVisible=True")) "login appeared"
+    Check "session data loaded"  ($out -match 'RESULT_sessionPct=\d') "session pct missing"
+    # 0% is only acceptable if the timer also says Not started (genuinely no usage)
+    $joined = $out -join "`n"
+    $pct  = if ($joined -match "RESULT_sessionPct=(.+)"  ) { $Matches[1].Trim() } else { "" }
+    $time = if ($joined -match "RESULT_sessionTime=(.+)" ) { $Matches[1].Trim() } else { "" }
+    if ($pct -eq "0%") {
+        Check "0% matches Not started" ($time -eq "Not started") "0% but timer says '$time' — stale/wrong fetch"
+    }
+}
+
+# ── TEST 4: all-accounts panel ────────────────────────────────────────────────
+Write-Host "`n=== TEST 4: All-accounts panel ===" -ForegroundColor Cyan
+$out = bh ($H + @"
+close_settings_if_open()
+state = widget_state()
+if state["allAccBtn"] == "none":
+    print("RESULT_skipped=one_account")
+else:
+    b = btn_pos("#allAccountsBtn")
+    # If panel is already open from a previous run, close it first
+    if state["multiSection"] != "none":
+        click_at_xy(b["x"], b["y"])
+        time.sleep(0.5)
+    click_at_xy(b["x"], b["y"])
+    time.sleep(6.0)   # sequential fetches take a few seconds each
+    state = widget_state()
+    blocks  = js('document.querySelectorAll(".multi-account-block").length')
+    errors  = js('Array.from(document.querySelectorAll(".multi-account-error")).map(e=>e.textContent.trim())')
+    screenshot("4-all-accounts")
+    print(f"multiSection={state['multiSection']} blocks={blocks} errors={errors}")
+    print("RESULT_sectionVisible=" + str(state["multiSection"] != "none"))
+    print("RESULT_blocks=" + str(blocks))
+    print("RESULT_errors=" + str(errors))
+    # Close panel
+    click_at_xy(b["x"], b["y"])
+    time.sleep(0.4)
+"@)
+if ($out -match "RESULT_skipped") {
+    Write-Host "  SKIP: only one account" -ForegroundColor Yellow
+} else {
+    Check "panel opened"      ($out -match "RESULT_sectionVisible=True") "multiSection stayed hidden"
+    Check "blocks rendered"   ($out -match "RESULT_blocks=[1-9]") "no account blocks rendered"
+    Check "no fetch errors"   (-not ($out -match "RESULT_errors=\['.+'\]")) ($out | Select-String "RESULT_errors")
+}
+
+# ── TEST 5: refresh ───────────────────────────────────────────────────────────
+Write-Host "`n=== TEST 5: Refresh ===" -ForegroundColor Cyan
+$out = bh ($H + @"
+close_settings_if_open()
+before = widget_state()
+b = btn_pos("#refreshBtn")
+click_at_xy(b["x"], b["y"])
+time.sleep(5.0)
+after = widget_state()
+screenshot("5-after-refresh")
+print(f"Before: session={before['sessionPct']} weekly={before['weeklyPct']}")
+print(f"After:  session={after['sessionPct']}  weekly={after['weeklyPct']}")
+print("RESULT_loginVisible=" + str(after["loginVisible"]))
+print("RESULT_sessionPct=" + str(after["sessionPct"]))
+"@)
+Check "no login after refresh"  (-not ($out -match "RESULT_loginVisible=True")) "login appeared"
+Check "data present after refresh" ($out -match 'RESULT_sessionPct=\d') "sessionPct gone after refresh"
+
+# ── summary ───────────────────────────────────────────────────────────────────
+Write-Host "`n=== SUMMARY ===" -ForegroundColor Cyan
+Write-Host "  Passed: $pass" -ForegroundColor Green
+if ($fail -gt 0) {
+    Write-Host "  Failed: $fail" -ForegroundColor Red
+} else {
+    Write-Host "  Failed: $fail" -ForegroundColor Green
+}
+Write-Host "  Screenshots: test-*.png in the widget folder"
+
+# Restore BU_CDP_URL so this script doesn't pollute the shell session
+$env:BU_CDP_URL = $_old_cdp


### PR DESCRIPTION
  Adds the ability to save and switch between multiple Claude accounts without logging out and back in.

  What's new:

  Core feature
  - Save multiple accounts (Settings → Accounts → + Add). Each account goes through the existing login flow and
  stores its session key in the OS keychain (DPAPI on Windows, Keychain on macOS).
  - Switch accounts instantly with a single click. The session cookie is swapped and usage data refreshes
  automatically when Settings closes.
  - Active account is marked with an "active" badge; the Switch button is hidden for it.
  - Active account name shown above "Current Session" in the main widget when 2+ accounts are saved.

  All-accounts view
  - People icon button in the toolbar (visible when 2+ accounts saved) opens a panel showing session and weekly
  usage bars for every non-active account, fetched sequentially.
  - Panel refreshes automatically on each auto-update cycle and on manual refresh.

  Safety / UX
  - Cannot delete the active account or your last remaining account — both blocked with an inline error message.
  - Widget does not resize while Settings is open — fixes a race condition where switching accounts would collapse
  the window to 155px.
  - Stale all-accounts panel re-renders immediately after switching accounts.

  Bug fixes included
  - fetchUsageData, getCredentials, and startup all now route through a shared decryptKey() helper with a plain-text
  fallback, fixing silent 0% / "Not started" after switching on Windows where safeStorage.isEncryptionAvailable()
  returns false before app.ready.
  - Fixed options being dropped from fetchUsageData IPC call in preload.

  Testing
  - test-widget.ps1: automated CDP stress test via browser-harness covering baseline state, settings/accounts panel,
  account switching, all-accounts panel, and refresh. Run npm run dev then .\test-widget.ps1. Requires
  browser-harness (https://github.com/browser-use/browser-harness).

  Platforms tested

  - Windows 11
<img width="840" height="447" alt="test-1-baseline" src="https://github.com/user-attachments/assets/e3e27685-9332-421b-981c-ad73a5d5028e" />
<img width="840" height="660" alt="test-2-settings-open" src="https://github.com/user-attachments/assets/a4c1459a-439a-406d-a94d-a136496848e4" />
<img width="840" height="447" alt="test-3-main-after-switch" src="https://github.com/user-attachments/assets/b38a4744-82de-4418-aae2-faa29796eb8c" />
<img width="840" height="660" alt="test-3-settings-after-switch" src="https://github.com/user-attachments/assets/c7fc9054-9562-4ce5-9d91-0c0bc2452571" />
<img width="840" height="447" alt="test-4-all-accounts" src="https://github.com/user-attachments/assets/00e5fc18-fa3c-44ba-b2ce-f02f32aa025c" />
<img width="840" height="321" alt="test-5-after-refresh" src="https://github.com/user-attachments/assets/6e15d5fe-5def-4be4-8b81-04192effd8e2" />

