### PR TITLE
[codex] Add automated separate macOS builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -63,7 +63,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           draft: false
-          prerelease: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/*x86_64*.AppImage
             dist/*arm64*.AppImage

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -10,13 +10,16 @@ on:
 
 jobs:
   build:
+    name: Build macOS ${{ matrix.arch }} DMG
     runs-on: macos-latest
     permissions:
       contents: write
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18]
+        arch: [arm64, x64]
 
     steps:
       - name: Checkout
@@ -37,7 +40,15 @@ jobs:
           npm pkg set version="$VERSION"
 
       - name: Import macOS certificates
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
+          if [ -z "$CSC_LINK" ] || [ -z "$CSC_KEY_PASSWORD" ]; then
+            echo "macOS signing certificate secrets are not configured; building unsigned DMG."
+            exit 0
+          fi
+
           # Create keychain
           security create-keychain -p "" build.keychain
           security set-keychain-settings -t 3600 -u build.keychain
@@ -45,11 +56,11 @@ jobs:
           security unlock-keychain -p "" build.keychain
           
           # Write base64 to file, then decode
-          echo '${{ secrets.CSC_LINK }}' > certificate.b64
+          printf '%s' "$CSC_LINK" > certificate.b64
           base64 --decode -i certificate.b64 -o certificate.p12
           
           # Import certificate
-          security import certificate.p12 -k build.keychain -P '${{ secrets.CSC_KEY_PASSWORD }}' -T /usr/bin/codesign -T /usr/bin/productbuild
+          security import certificate.p12 -k build.keychain -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
           
           # Set keychain partition list
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
@@ -60,39 +71,34 @@ jobs:
           # Cleanup
           rm -f certificate.p12 certificate.b64
 
-      - name: Build Electron app (DMG)
-        run: npm run build:mac
+      - name: Build Electron app (${{ matrix.arch }} DMG)
+        run: |
+          if security list-keychains | grep -q 'build.keychain'; then
+            CSC_KEYCHAIN=build.keychain npm run build:mac:${{ matrix.arch }}
+          else
+            CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac:${{ matrix.arch }}
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_KEYCHAIN: build.keychain
 
-      - name: Upload arm64 DMG
+      - name: Upload ${{ matrix.arch }} DMG artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Claude-Usage-Widget-arm64
-          path: dist/*arm64*.dmg
+          name: Claude-Usage-Widget-macOS-${{ matrix.arch }}
+          path: dist/*${{ matrix.arch }}*.dmg
           if-no-files-found: error
 
-      - name: Upload x64 DMG
-        uses: actions/upload-artifact@v4
-        with:
-          name: Claude-Usage-Widget-x64
-          path: dist/*x64*.dmg
-          if-no-files-found: error
-
-      - name: Upload to Release
+      - name: Upload ${{ matrix.arch }} DMG to Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           draft: false
-          prerelease: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
-            dist/*arm64*.dmg
-            dist/*arm64*.dmg.blockmap
-            dist/*x64*.dmg
-            dist/*x64*.dmg.blockmap
+            dist/*${{ matrix.arch }}*.dmg
+            dist/*${{ matrix.arch }}*.dmg.blockmap
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -61,7 +61,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           draft: false
-          prerelease: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/*Setup*.exe
             dist/*portable*.exe

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -8,12 +8,13 @@
    git push origin v1.7.1-rc.1
    ```
 
-2. **GitHub Actions will build all platforms** automatically
+2. **GitHub Actions will build all platforms** automatically:
+   - Windows Setup + Portable
+   - macOS Apple Silicon (`arm64`) DMG
+   - macOS Intel (`x64`) DMG
+   - Linux `x86_64` + `arm64` AppImages
 
-3. **Mark the GitHub Release as "Pre-release":**
-   - Go to the release on GitHub
-   - Check "This is a pre-release" checkbox
-   - This prevents user notifications
+3. **The GitHub Release is marked as "Pre-release" automatically** for tags containing a hyphen, such as `v1.7.1-rc.1` or `v1.7.1-beta.1`.
 
 4. **Test the builds:**
    - Download and test Windows, macOS, Linux builds
@@ -35,14 +36,14 @@
    git push origin v1.7.1
    ```
 
-2. **Create the final GitHub Release:**
-   - **DO NOT** check "This is a pre-release"
-   - Paste release notes from CHANGELOG.md
+2. **GitHub Actions will create/update the final GitHub Release automatically:**
+   - Stable tags without a hyphen, such as `v1.7.1`, are not marked as pre-release
+   - Paste release notes from CHANGELOG.md after the release is created
    - Users will be notified of this version only
 
 ## Important Notes
 
-- **Pre-release tags do not notify users** if marked as pre-release on GitHub
+- **Pre-release tags do not notify users** because tags containing a hyphen are automatically marked as pre-release on GitHub
 - **Final tags notify all users** watching the repo
 - **Never delete and re-push final tags** — use RC tags for testing
 - **Always test locally** with `npm start` before pushing any tags

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build:win": "electron-builder --win",
     "dev": "cross-env NODE_ENV=development electron .",
     "build:mac": "electron-builder --mac",
+    "build:mac:arm64": "electron-builder --mac --arm64",
+    "build:mac:x64": "electron-builder --mac --x64",
     "build:linux": "electron-builder --linux"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- Split macOS CI into separate arm64 and x64 matrix builds
- Add explicit npm scripts for each macOS architecture
- Make release prerelease status derive from tag names and update release docs

## Validation
- Parsed package.json with Node
- Parsed all workflow YAML files with Ruby
- Ran git diff --check