### PR TITLE
Surface scoped weekly limits from the `limits` array (Fable) + fix extra-row timer pairing

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -730,14 +730,17 @@ function buildExtraRows(data) {
 }
 
 function refreshExtraTimers() {
-    const timerTexts = elements.extraRows.querySelectorAll('.timer-text');
-    const timerCircles = elements.extraRows.querySelectorAll('.timer-progress');
-
-    timerTexts.forEach((textEl, i) => {
+    // Pair each row's timer text with its own circle. Pairing the two
+    // querySelectorAll lists by index breaks as soon as one row has a text
+    // but no circle (the extra_usage row), leaving every later row's timer
+    // stuck at --:--.
+    elements.extraRows.querySelectorAll('.usage-section').forEach((row) => {
+        const textEl = row.querySelector('.timer-text');
+        const circleEl = row.querySelector('.timer-progress');
+        if (!textEl || !circleEl) return;
         const resetsAt = textEl.dataset.resets;
         const totalMinutes = parseInt(textEl.dataset.total);
-        const circleEl = timerCircles[i];
-        if (resetsAt && circleEl) {
+        if (resetsAt) {
             updateTimer(circleEl, textEl, resetsAt, totalMinutes);
         }
     });

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -761,6 +761,23 @@ function resizeWidget(bannerVisible) {
 }
 
 function normalizeUsageData(data) {
+    // claude.ai now reports per-model weekly limits (e.g. Fable) as entries in
+    // the `limits` array with kind "weekly_scoped"; the legacy seven_day_<model>
+    // fields arrive null for those models. Map each scoped weekly limit onto a
+    // synthetic seven_day_* field so it renders like any other extra row.
+    for (const limit of (data.limits || [])) {
+        if (limit.kind !== 'weekly_scoped' || limit.percent == null) continue;
+        const scopeName = limit.scope?.model?.display_name || limit.scope?.surface || 'Scoped';
+        const key = 'seven_day_scoped_' + scopeName.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+        if (!EXTRA_ROW_CONFIG[key]) {
+            EXTRA_ROW_CONFIG[key] = { label: `${scopeName} (7d)`, color: 'opus' };
+            // Re-insert extra_usage so model rows stay grouped above it
+            const extraUsage = EXTRA_ROW_CONFIG.extra_usage;
+            delete EXTRA_ROW_CONFIG.extra_usage;
+            EXTRA_ROW_CONFIG.extra_usage = extraUsage;
+        }
+        data[key] = { utilization: limit.percent, resets_at: limit.resets_at };
+    }
     return data;
 }
 


### PR DESCRIPTION
Fixes #97

**What this does**

Two commits:

1. **feat: surface scoped weekly limits from the `limits` array.** claude.ai now reports per-model weekly limits (e.g. Fable) as `limits[]` entries with `kind: "weekly_scoped"` and sends the legacy `seven_day_<model>` fields as `null`, so current accounts get no model bar at all. `normalizeUsageData()` (previously a no-op) now maps each scoped weekly limit onto a synthetic `seven_day_*` field and registers a row config on the fly, labelled from the API's `display_name`. It's deliberately generic: whatever scoped limits Anthropic sends next will render without another release. Existing legacy fields still take priority for accounts that receive them, and `extra_usage` is re-inserted last so the model rows stay grouped above it.

2. **fix: pair extra-row timers per row instead of by list index.** `refreshExtraTimers()` zipped two `querySelectorAll` lists by index, but the `extra_usage` row has a `.timer-text` and no `.timer-progress` circle, so every row after it got the wrong circle and a countdown stuck at `--:--`. Now each row pairs its own text and circle, and rows without both are skipped. Without this fix, dynamically-added rows from commit 1 that land after `extra_usage` show no countdown.

**Choices worth flagging**

- New scoped rows reuse the `opus` colour class rather than adding CSS per model. Happy to add a dedicated class if you'd prefer.
- The synthetic key is prefixed `seven_day_` because the row renderer keys its 7-day elapsed-circle maths off that substring.

**Tested**

Repacked into the v1.7.5 Linux AppImage asar and ran it against the live API on a Claude Max account with a Fable limit: the `Fable (7d)` row renders with the correct percentage and reset time, updates across 30s polls, and the countdown circle fills correctly after commit 2. `node --check` passes on `src/renderer/app.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
