### PR TITLE
feat: Session Slot Scheduler — target your 5-hour window start times

### DIFF
--- a/docs/plans/2026-07-11-session-slot-scheduler-design.md
+++ b/docs/plans/2026-07-11-session-slot-scheduler-design.md
@@ -57,17 +57,29 @@ idleTo   = firstFiller                                 // == Ts when numFillers 
 triggerTimes = [firstFiller, firstFiller+FIVE_H, …, Ts]  // numFillers + 1 sends
 ```
 
-Filler windows are placed contiguous, ending exactly at `Ts`, with the leftover
-idle pushed to the front (right after the current session ends). The widget
-auto-sends "hi" at every `triggerTime`. Filler windows are the user's to use or
-ignore; opening one costs a single throwaway message. The final trigger at `Ts`
-opens the real target window and is guaranteed regardless of whether the fillers
-were used.
+Filler windows run **contiguous from the moment the current session ends**, and
+the leftover idle slack is pushed to the **end** — the stretch right before the
+target. This is deliberate: for a morning target the idle lands in the pre-dawn
+hours (while the user is asleep) instead of wasting waking daytime. Placing the
+idle at the front (the first implementation) told the user to sit idle 11:00–15:00,
+which is exactly the productive time they wanted to keep. The widget auto-sends
+"hi" at every `triggerTime`. Filler windows are the user's to use or ignore;
+opening one costs a single throwaway message. The final trigger at `Ts` opens the
+real target window and is guaranteed regardless of whether the fillers were used.
+
+```
+startMs = E
+triggerTimes = [E, E+5h, …, E+(numFillers-1)*5h, Ts]   // fillers back-to-back, then target
+idleFrom = E + numFillers*5h                            // last filler's end
+idleTo   = Ts                                           // idle sits just before target
+```
 
 Worked examples (target 08:00):
 - Current ends 05:00 → gap 3h, 0 fillers → idle 05:00–08:00, one send at 08:00.
-- Current ends 00:00 → gap 8h, 1 filler → idle 00:00–03:00, send 03:00 (filler
-  03:00–08:00), send 08:00 (target).
+- Current ends 00:00 → gap 8h, 1 filler → send 00:00 (filler 00:00–05:00), idle
+  05:00–08:00, send 08:00 (target).
+- Current ends 11:00, target 06:00 → 3 fillers 11:00/16:00/21:00 covering the
+  waking day, idle 02:00–06:00 (asleep), send 06:00.
 - No active window, armed at 07:10 → Ts today 08:00 → idle until 08:00, send.
 - No active window, armed at 09:30 (08:00 passed) → Ts tomorrow 08:00.
 

--- a/docs/plans/2026-07-11-session-slot-scheduler-design.md
+++ b/docs/plans/2026-07-11-session-slot-scheduler-design.md
@@ -1,0 +1,126 @@
+# Session Slot Scheduler — Design
+
+Date: 2026-07-11
+Feature branch: `feature/session-slot-scheduler`
+
+## Problem
+
+Claude.ai enforces a rolling 5-hour usage window. The window opens the moment
+you send the first message after the previous window has reset, and it always
+runs a full 5 hours. Because most users just fire off a message whenever, their
+window boundaries drift to arbitrary times (9 AM–2 PM, 2 PM–7 PM, 7 PM–12 AM …)
+and never line up with the hours they actually want to work.
+
+The user wants to *target* specific start times — "I want my 5-hour slot to
+begin at 8 AM" — and have the widget put the window there automatically by
+sending a single throwaway message ("hi") at exactly the right moment.
+
+## Core mechanic (the lever)
+
+A window's start time only advances when you send the **first message after a
+reset**. Staying idle freezes the boundary — the next window will not begin
+until a message is sent. So aligning to a target time `Ts` means:
+
+1. Ensure no active window is still running past `Ts` (the previous window has
+   reset at or before `Ts`).
+2. Send the first message exactly at `Ts`.
+
+The widget already holds an authenticated Claude.ai session, so it can send that
+message for you.
+
+## Decisions (from brainstorming)
+
+- **Trigger:** auto-send "hi" via the Claude.ai API using the stored session.
+- **Scheduling model:** multiple named slots (e.g. Early 08:00, Mid 13:00); arm
+  one per day.
+- **Message target:** a single dedicated, reused conversation ("⏱ Slot
+  Starter") so the chat list isn't flooded with "hi" threads.
+- **Filler handling:** fully auto-manage the chain — the widget also opens the
+  optional filler windows between now and the target so no usable time is
+  wasted, while still guaranteeing the target landing.
+- **Guard style:** prominent in-widget banner **plus** desktop notifications.
+
+## Planner algorithm
+
+Inputs: `slotTime` ("HH:MM", local), `resetsAt` (ISO of current window reset, or
+null / past when no window is active), `now`.
+
+```
+E  = active window? new Date(resetsAt) : now          // current session end
+Ts = next occurrence of slotTime at-or-after E         // target start
+gap = Ts - E
+FIVE_H = 5h
+numFillers = floor(gap / FIVE_H)
+firstFiller = Ts - numFillers * FIVE_H                 // >= E, so idle < 5h
+idleFrom = E
+idleTo   = firstFiller                                 // == Ts when numFillers == 0
+triggerTimes = [firstFiller, firstFiller+FIVE_H, …, Ts]  // numFillers + 1 sends
+```
+
+Filler windows are placed contiguous, ending exactly at `Ts`, with the leftover
+idle pushed to the front (right after the current session ends). The widget
+auto-sends "hi" at every `triggerTime`. Filler windows are the user's to use or
+ignore; opening one costs a single throwaway message. The final trigger at `Ts`
+opens the real target window and is guaranteed regardless of whether the fillers
+were used.
+
+Worked examples (target 08:00):
+- Current ends 05:00 → gap 3h, 0 fillers → idle 05:00–08:00, one send at 08:00.
+- Current ends 00:00 → gap 8h, 1 filler → idle 00:00–03:00, send 03:00 (filler
+  03:00–08:00), send 08:00 (target).
+- No active window, armed at 07:10 → Ts today 08:00 → idle until 08:00, send.
+- No active window, armed at 09:30 (08:00 passed) → Ts tomorrow 08:00.
+
+## Guard
+
+The widget cannot stop the user typing directly in claude.ai, so during the
+front idle window `[idleFrom, idleTo]` it shows a prominent banner
+("IDLE until 8:00 AM to hit your target — don't send anything") and fires a
+desktop notification when the idle window starts. Sending during the idle window
+would open a misaligned window and push the target to its next occurrence.
+
+## Robustness / re-planning
+
+- On every usage refresh and on a 15-second scheduler tick, the plan is
+  recomputed from the current `resetsAt`. If the user broke the plan (sent a
+  message during idle → `resetsAt` jumped), the boundary shift is detected, the
+  plan recomputed, and a "Plan changed" notification fired.
+- Missed triggers (app closed / machine asleep): on launch / next tick the
+  planner recomputes to the next valid target and notifies that a trigger was
+  missed.
+- Send failures fall back to a desktop notification asking the user to send "hi"
+  manually, so a flaky API never silently drops the slot.
+- Arming is one-shot per day: after the final target trigger fires, the slot is
+  disarmed and the user re-arms next day. (Daily-repeat is a future extension.)
+
+## Architecture
+
+The scheduler, planner, and sender live in the **main process** — triggers must
+fire reliably regardless of renderer state, and the send needs a `BrowserWindow`.
+
+- `src/slot-planner.js` — pure `computePlan({ slotTime, resetsAt, now })`.
+  Unit-tested with a plain Node script (no test framework in the project).
+- `src/slot-sender.js` — `sendSlotStarter({ organizationId, conversationId })`.
+  Loads `https://claude.ai` in a hidden `BrowserWindow` and runs a `fetch()`
+  **in the page context** (rides session cookies + real Chrome UA, bypassing
+  Cloudflare, same trick as `fetch-via-window.js` but for POST). Creates the
+  dedicated conversation on first use, reuses its UUID after.
+- `main.js` — slot CRUD + arm/disarm IPC, a 15s scheduler interval, plan
+  recompute on refresh, `slot-update` push to the renderer, desktop
+  notifications.
+- `preload.js` — expose `getSlots/saveSlots/armSlot/disarmSlot/getSlotState`
+  and an `onSlotUpdate` listener.
+- `index.html` + `app.js` + `styles.css` — a "Slots" toolbar toggle opening a
+  panel: named-slot list with add/edit/delete, an Arm button per slot, a live
+  plan panel, and the guard banner.
+
+## Data model (electron-store)
+
+- `slots`: `[{ id, label, time }]` (defaults seeded on first run).
+- `armedSlot`: `{ slotId, firedUpTo }` or null.
+- `slotStarterConversationId`: reused conversation UUID.
+
+## Out of scope (YAGNI)
+
+- Daily-repeat arming, per-slot notification customization, weekly-limit-aware
+  planning. Revisit only if requested.

--- a/main.js
+++ b/main.js
@@ -3,6 +3,8 @@ const path = require('path');
 const https = require('https');
 const Store = require('electron-store');
 const { fetchViaWindow, fetchMultipleViaWindow } = require('./src/fetch-via-window');
+const { computePlan, FIVE_HOURS_MS } = require('./src/slot-planner');
+const { sendSlotStarter } = require('./src/slot-sender');
 
 const GITHUB_OWNER = 'SlavomirDurej';
 const GITHUB_REPO = 'claude-usage-widget';
@@ -990,6 +992,237 @@ ipcMain.on('show-notification', (event, { title, body }) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Session Slot Scheduler
+//
+// Lets the user target specific 5-hour window start times (e.g. "start my slot
+// at 8 AM") and auto-sends a throwaway "hi" at the right moments to align the
+// window. See src/slot-planner.js for the planning maths and
+// src/slot-sender.js for the send mechanism, and docs/plans for the design.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SLOTS = [
+  { id: 'slot-early', label: 'Early', time: '06:00' },
+  { id: 'slot-morning', label: 'Morning', time: '08:00' },
+  { id: 'slot-afternoon', label: 'Afternoon', time: '13:00' },
+];
+
+let slotSending = false;
+// In-memory per-arm notification state (reset on arm / after firing target).
+let slotNotify = { idleNotified: false, lastTargetMs: null };
+
+function resetSlotNotify() {
+  slotNotify = { idleNotified: false, lastTargetMs: null };
+}
+
+function getSlots() {
+  let slots = store.get('slots');
+  if (!Array.isArray(slots)) {
+    slots = DEFAULT_SLOTS;
+    store.set('slots', slots);
+  }
+  return slots;
+}
+
+function findSlot(slotId) {
+  return getSlots().find((s) => s.id === slotId) || null;
+}
+
+function getArmed() {
+  return store.get('armedSlot') || null;
+}
+
+function setArmed(v) {
+  if (v) store.set('armedSlot', v);
+  else store.delete('armedSlot');
+}
+
+// Lightweight time formatter for notifications (renderer formats its own UI).
+function formatSlotTime(date) {
+  const use24h = store.get('settings.timeFormat', '12h') === '24h';
+  let h = date.getHours();
+  const m = String(date.getMinutes()).padStart(2, '0');
+  if (use24h) return `${String(h).padStart(2, '0')}:${m}`;
+  const ampm = h >= 12 ? 'PM' : 'AM';
+  h = h % 12 || 12;
+  return `${h}:${m} ${ampm}`;
+}
+
+function notifySlot(title, body) {
+  if (Notification.isSupported()) {
+    new Notification({ title, body, silent: false }).show();
+  }
+}
+
+// Serialise a plan (Dates -> ISO) for the renderer, with a few derived flags.
+function serializePlan(plan, now) {
+  const inIdleNow =
+    plan.hasIdle && now >= plan.idleFrom.getTime() && now < plan.idleTo.getTime();
+  const nextTrigger = plan.triggerTimes.find((t) => t.getTime() > now) || null;
+  return {
+    currentSessionEnd: plan.currentSessionEnd.toISOString(),
+    windowActive: plan.windowActive,
+    targetAt: plan.targetAt.toISOString(),
+    numFillers: plan.numFillers,
+    triggerTimes: plan.triggerTimes.map((t) => t.toISOString()),
+    idleFrom: plan.idleFrom.toISOString(),
+    idleTo: plan.idleTo.toISOString(),
+    hasIdle: plan.hasIdle,
+    inIdleNow,
+    nextTriggerAt: nextTrigger ? nextTrigger.toISOString() : null,
+  };
+}
+
+function currentResetsAt() {
+  return store.get('latestUsageData')?.five_hour?.resets_at || null;
+}
+
+// Push current slot state (list + armed + live plan) to the renderer.
+function pushSlotState(extra = {}) {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  const armed = getArmed();
+  const now = Date.now();
+  let slot = null;
+  let plan = null;
+  if (armed) {
+    slot = findSlot(armed.slotId);
+    if (slot) {
+      const p = computePlan({ slotTime: slot.time, resetsAt: currentResetsAt(), now: new Date(now) });
+      plan = serializePlan(p, now);
+    }
+  }
+  mainWindow.webContents.send('slot-update', {
+    slots: getSlots(),
+    armed,
+    slot,
+    plan,
+    ...extra,
+  });
+}
+
+// The scheduler heartbeat: recompute the plan, warn about idle, and fire any
+// due trigger. Runs every 15s and also right after each usage refresh.
+async function tickSlotScheduler() {
+  const armed = getArmed();
+  if (!armed) return;
+
+  const slot = findSlot(armed.slotId);
+  if (!slot) {
+    setArmed(null);
+    resetSlotNotify();
+    pushSlotState();
+    return;
+  }
+
+  const now = new Date();
+  const plan = computePlan({ slotTime: slot.time, resetsAt: currentResetsAt(), now });
+  const targetMs = plan.targetAt.getTime();
+
+  // Detect a plan shift (e.g. user broke idle and the window moved).
+  if (slotNotify.lastTargetMs != null && slotNotify.lastTargetMs !== targetMs) {
+    notifySlot('Slot plan changed', `${slot.label}: your window now lands at ${formatSlotTime(plan.targetAt)}.`);
+    slotNotify.idleNotified = false;
+  }
+  slotNotify.lastTargetMs = targetMs;
+
+  // Idle guard — notify once when the "do not send" window begins.
+  const inIdle = plan.hasIdle && now >= plan.idleFrom && now < plan.idleTo;
+  if (inIdle && !slotNotify.idleNotified) {
+    notifySlot('Stay idle to hit your slot', `Don't send anything until ${formatSlotTime(plan.idleTo)} or your ${slot.label} target will shift.`);
+    slotNotify.idleNotified = true;
+  }
+
+  // Fire due triggers. If several elapsed while the app was closed, one send is
+  // enough to claim the currently-open window, so fire only the latest.
+  const firedUpTo = armed.firedUpTo ? new Date(armed.firedUpTo).getTime() : 0;
+  const due = plan.triggerTimes.filter((t) => t.getTime() <= now.getTime() && t.getTime() > firedUpTo);
+
+  if (due.length && !slotSending) {
+    const target = due[due.length - 1];
+    const isFinal = target.getTime() === targetMs;
+    slotSending = true;
+    try {
+      const result = await sendSlotStarter({
+        organizationId: store.get('organizationId'),
+        conversationId: store.get('slotStarterConversationId') || null,
+      });
+      if (result && result.conversationId) {
+        store.set('slotStarterConversationId', result.conversationId);
+      }
+      if (result && result.ok) {
+        setArmed({ slotId: armed.slotId, firedUpTo: target.toISOString() });
+        if (isFinal) {
+          const endsAt = new Date(target.getTime() + FIVE_HOURS_MS);
+          notifySlot('Slot started', `${slot.label} window opened — runs until ${formatSlotTime(endsAt)}.`);
+          setArmed(null);
+          resetSlotNotify();
+        } else {
+          notifySlot('Interim window opened', `${slot.label}: filler window opened, still targeting ${formatSlotTime(plan.targetAt)}.`);
+        }
+        // Refresh usage so the UI reflects the newly opened window promptly.
+        if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send('refresh-usage');
+      } else {
+        notifySlot('Slot send failed', `Couldn't start ${slot.label} automatically — send "hi" to Claude yourself. ${result && result.error ? '(' + result.error + ')' : ''}`);
+      }
+    } catch (err) {
+      notifySlot('Slot send failed', `Couldn't start ${slot.label} automatically — send "hi" to Claude yourself.`);
+      debugLog('[Slots] send error:', err && err.message);
+    } finally {
+      slotSending = false;
+    }
+  }
+
+  pushSlotState();
+}
+
+ipcMain.handle('get-slot-state', () => {
+  const armed = getArmed();
+  const now = Date.now();
+  let slot = null;
+  let plan = null;
+  if (armed) {
+    slot = findSlot(armed.slotId);
+    if (slot) {
+      const p = computePlan({ slotTime: slot.time, resetsAt: currentResetsAt(), now: new Date(now) });
+      plan = serializePlan(p, now);
+    }
+  }
+  return { slots: getSlots(), armed, slot, plan };
+});
+
+ipcMain.handle('save-slots', (event, slots) => {
+  if (!Array.isArray(slots)) return { ok: false };
+  // Basic validation/normalisation.
+  const clean = slots
+    .filter((s) => s && s.id && /^\d{1,2}:\d{2}$/.test(s.time))
+    .map((s) => ({ id: String(s.id), label: String(s.label || 'Slot').slice(0, 24), time: s.time }));
+  store.set('slots', clean);
+  // If the armed slot was deleted, disarm.
+  const armed = getArmed();
+  if (armed && !clean.find((s) => s.id === armed.slotId)) {
+    setArmed(null);
+    resetSlotNotify();
+  }
+  pushSlotState();
+  return { ok: true, slots: clean };
+});
+
+ipcMain.handle('arm-slot', (event, slotId) => {
+  const slot = findSlot(slotId);
+  if (!slot) return { ok: false, error: 'Unknown slot' };
+  setArmed({ slotId, firedUpTo: null });
+  resetSlotNotify();
+  tickSlotScheduler();
+  return { ok: true };
+});
+
+ipcMain.handle('disarm-slot', () => {
+  setArmed(null);
+  resetSlotNotify();
+  pushSlotState();
+  return { ok: true };
+});
+
 // Resize window for compact vs normal mode
 // Compact: 290px wide, normal: 530px wide. Height stays managed by renderer.
 ipcMain.on('set-compact-mode', (event, compact) => {
@@ -1389,6 +1622,9 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
   // Store latest usage data for settings refresh
   store.set('latestUsageData', data);
 
+  // Recompute the slot plan against the freshly fetched reset time.
+  tickSlotScheduler();
+
   // Update tray icon with current usage data
   updateTrayIcon(data);
 
@@ -1446,6 +1682,15 @@ app.whenReady().then(async () => {
     }
     mainWindow.setAlwaysOnTop(alwaysOnTop, 'floating');
   }
+
+  // Seed default slots on first run so the panel isn't empty.
+  getSlots();
+
+  // Slot scheduler heartbeat — fires due triggers and updates the guard banner
+  // even between usage refreshes.
+  setInterval(() => {
+    tickSlotScheduler();
+  }, 15000);
 
   // Periodic always-on-top re-assertion to recover from z-order disruptions
   // (hidden window spawns, window manager shortcuts, alt-tab, etc.)

--- a/main.js
+++ b/main.js
@@ -1643,6 +1643,13 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
 
 // App lifecycle
 app.whenReady().then(async () => {
+  // Windows requires an explicit AppUserModelId for desktop toast notifications
+  // to appear at all (usage alerts AND slot idle/trigger alerts). Without it,
+  // new Notification().show() silently no-ops in unpackaged/portable runs.
+  if (process.platform === 'win32') {
+    app.setAppUserModelId('com.claudeusage.widget');
+  }
+
   // Restore session cookie if we have stored credentials
   let sessionKey = null;
   if (safeStorage.isEncryptionAvailable()) {

--- a/preload.js
+++ b/preload.js
@@ -71,5 +71,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   showNotification: (title, body) => ipcRenderer.send('show-notification', { title, body }),
 
   // Compact mode
-  setCompactMode: (compact) => ipcRenderer.send('set-compact-mode', compact)
+  setCompactMode: (compact) => ipcRenderer.send('set-compact-mode', compact),
+
+  // Session slot scheduler
+  getSlotState: () => ipcRenderer.invoke('get-slot-state'),
+  saveSlots: (slots) => ipcRenderer.invoke('save-slots', slots),
+  armSlot: (slotId) => ipcRenderer.invoke('arm-slot', slotId),
+  disarmSlot: () => ipcRenderer.invoke('disarm-slot'),
+  onSlotUpdate: (callback) => {
+    ipcRenderer.on('slot-update', (_event, state) => callback(state));
+  }
 });

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -9,12 +9,15 @@ let _settingsOpenedFromCompact = false;
 let usageChart = null;
 let graphVisible = false;
 let graphWasVisible = false; // preserves graph state across compact mode toggle
+let slotsVisible = false;
+let slotState = { slots: [], armed: null, slot: null, plan: null };
 let appInitializing = true;  // suppresses _saveViewState during startup restore
 let isFetching = false;       // in-flight guard — prevents overlapping fetchUsageData calls
 const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const WIDGET_HEIGHT_COLLAPSED = 155;
 const WIDGET_ROW_HEIGHT = 30;
 const GRAPH_HEIGHT = 232;
+const SLOTS_HEIGHT = 200;
 
 // Debug logging — only shows in DevTools (development mode).
 // Regular users won't see verbose logs in production.
@@ -63,6 +66,19 @@ const elements = {
     extraRows: document.getElementById('extraRows'),
     graphSection: document.getElementById('graphSection'),
     usageChart: document.getElementById('usageChart'),
+
+    slotsBtn: document.getElementById('slotsBtn'),
+    slotsSection: document.getElementById('slotsSection'),
+    slotBanner: document.getElementById('slotBanner'),
+    slotBannerText: document.getElementById('slotBannerText'),
+    slotPlan: document.getElementById('slotPlan'),
+    slotPlanArmed: document.getElementById('slotPlanArmed'),
+    slotPlanSteps: document.getElementById('slotPlanSteps'),
+    slotDisarmBtn: document.getElementById('slotDisarmBtn'),
+    slotList: document.getElementById('slotList'),
+    slotLabelInput: document.getElementById('slotLabelInput'),
+    slotTimeInput: document.getElementById('slotTimeInput'),
+    slotAddBtn: document.getElementById('slotAddBtn'),
 
     settingsBtn: document.getElementById('settingsBtn'),
     settingsOverlay: document.getElementById('settingsOverlay'),
@@ -260,6 +276,33 @@ function setupEventListeners() {
         }
         if (!isCompactMode) resizeWidget();
         _saveViewState();
+    });
+
+    // Slot scheduler panel toggle
+    elements.slotsBtn.addEventListener('click', () => {
+        slotsVisible = !slotsVisible;
+        elements.slotsBtn.classList.toggle('active', slotsVisible);
+        elements.slotsSection.style.display = slotsVisible ? 'block' : 'none';
+        if (slotsVisible) renderSlots();
+        if (!isCompactMode) resizeWidget();
+    });
+
+    // Add a new slot
+    elements.slotAddBtn.addEventListener('click', addSlotFromInputs);
+    elements.slotLabelInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') addSlotFromInputs();
+    });
+
+    // Disarm the currently armed slot
+    elements.slotDisarmBtn.addEventListener('click', async () => {
+        await window.electronAPI.disarmSlot();
+    });
+
+    // Receive live slot state pushed from the main process
+    window.electronAPI.onSlotUpdate((state) => {
+        slotState = state;
+        renderSlots();
+        renderSlotBanner();
     });
 
     elements.minimizeBtn.addEventListener('click', () => {
@@ -750,13 +793,15 @@ function resizeWidget(bannerVisible) {
     const hasBanner = bannerVisible !== undefined
         ? bannerVisible
         : elements.updateBanner.style.display !== 'none';
-    const bannerOffset = hasBanner ? BANNER_HEIGHT : 0;
+    const slotBannerVisible = elements.slotBanner && elements.slotBanner.style.display !== 'none';
+    const bannerOffset = (hasBanner ? BANNER_HEIGHT : 0) + (slotBannerVisible ? BANNER_HEIGHT : 0);
     const extraCount = elements.extraRows.children.length;
     const expandedOffset = isExpanded && extraCount > 0
         ? EXPAND_OVERHEAD + (extraCount * WIDGET_ROW_HEIGHT)
         : 0;
     const graphOffset = graphVisible ? GRAPH_HEIGHT : 0;
-    const totalHeight = WIDGET_HEIGHT_COLLAPSED + expandedOffset + graphOffset + bannerOffset;
+    const slotsOffset = slotsVisible ? SLOTS_HEIGHT : 0;
+    const totalHeight = WIDGET_HEIGHT_COLLAPSED + expandedOffset + graphOffset + slotsOffset + bannerOffset;
     window.electronAPI.resizeWindow(totalHeight);
 }
 
@@ -866,6 +911,13 @@ function applyCompactMode(compact) {
         elements.expandSection.style.display = 'none';
     }
 
+    // Hide the slots panel when entering compact mode
+    if (compact && slotsVisible) {
+        slotsVisible = false;
+        elements.slotsBtn.classList.remove('active');
+        elements.slotsSection.style.display = 'none';
+    }
+
     if (compact && graphVisible) {
         graphWasVisible = true;
         graphVisible = false;
@@ -888,6 +940,9 @@ function applyCompactMode(compact) {
     // Hide graph button in compact mode (not applicable)
     if (elements.graphBtn) {
         elements.graphBtn.style.display = compact ? 'none' : '';
+    }
+    if (elements.slotsBtn) {
+        elements.slotsBtn.style.display = compact ? 'none' : '';
     }
 
     // Tell main process to resize the window width
@@ -1200,6 +1255,7 @@ function showLoginRequired() {
     elements.settingsBtn.style.display = 'none';
     elements.refreshBtn.style.display = 'none';
     elements.graphBtn.style.display = 'none';
+    elements.slotsBtn.style.display = 'none';
     stopAutoUpdate();
     if (countdownInterval) {
         clearInterval(countdownInterval);
@@ -1236,6 +1292,7 @@ function showMainContent() {
     elements.settingsBtn.style.display = 'flex';
     elements.refreshBtn.style.display = 'flex';
     elements.graphBtn.style.display = isCompactMode ? 'none' : 'flex';
+    elements.slotsBtn.style.display = isCompactMode ? 'none' : 'flex';
 }
 
 // Auto-update management
@@ -1654,8 +1711,146 @@ async function checkForUpdate() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Session Slot Scheduler (renderer)
+// ---------------------------------------------------------------------------
+
+// Format an ISO timestamp as a clock time honouring the user's 12h/24h setting.
+function formatSlotClock(iso) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '—';
+    const use24h = ((window._cachedSettings || {}).timeFormat || '12h') === '24h';
+    let h = d.getHours();
+    const m = String(d.getMinutes()).padStart(2, '0');
+    if (use24h) return `${String(h).padStart(2, '0')}:${m}`;
+    const ampm = h >= 12 ? 'PM' : 'AM';
+    h = h % 12 || 12;
+    return `${h}:${m} ${ampm}`;
+}
+
+// Is the target on a later calendar day than now?
+function isTomorrow(iso) {
+    const d = new Date(iso);
+    const now = new Date();
+    return d.getDate() !== now.getDate() || d.getMonth() !== now.getMonth() || d.getFullYear() !== now.getFullYear();
+}
+
+async function loadSlotState() {
+    try {
+        slotState = await window.electronAPI.getSlotState();
+        renderSlots();
+        renderSlotBanner();
+    } catch (e) {
+        debugLog('loadSlotState failed', e);
+    }
+}
+
+async function addSlotFromInputs() {
+    const label = elements.slotLabelInput.value.trim() || 'Slot';
+    const time = elements.slotTimeInput.value;
+    if (!/^\d{1,2}:\d{2}$/.test(time)) return;
+    const id = 'slot-' + Date.now().toString(36);
+    const slots = [...(slotState.slots || []), { id, label, time }];
+    const res = await window.electronAPI.saveSlots(slots);
+    if (res && res.ok) {
+        slotState.slots = res.slots;
+        elements.slotLabelInput.value = '';
+        renderSlots();
+    }
+}
+
+async function deleteSlot(slotId) {
+    const slots = (slotState.slots || []).filter((s) => s.id !== slotId);
+    const res = await window.electronAPI.saveSlots(slots);
+    if (res && res.ok) {
+        slotState.slots = res.slots;
+        renderSlots();
+    }
+}
+
+async function armSlot(slotId) {
+    await window.electronAPI.armSlot(slotId);
+    // The main process pushes the fresh plan via onSlotUpdate.
+}
+
+function renderSlots() {
+    if (!elements.slotList) return;
+    const { slots = [], armed, plan, slot } = slotState;
+
+    // Slot list
+    elements.slotList.innerHTML = '';
+    slots.forEach((s) => {
+        const isArmed = armed && armed.slotId === s.id;
+        const row = document.createElement('div');
+        row.className = 'slot-item' + (isArmed ? ' armed' : '');
+        row.innerHTML = `
+            <span class="slot-item-label">${escapeHtml(s.label)}</span>
+            <span class="slot-item-time">${formatSlotClock(setTodayIso(s.time))}</span>
+            <button class="slot-arm-btn" data-arm="${s.id}">${isArmed ? 'Armed' : 'Arm'}</button>
+            <button class="slot-del-btn" data-del="${s.id}" title="Delete">✕</button>`;
+        elements.slotList.appendChild(row);
+    });
+
+    elements.slotList.querySelectorAll('[data-arm]').forEach((btn) => {
+        btn.addEventListener('click', () => armSlot(btn.getAttribute('data-arm')));
+    });
+    elements.slotList.querySelectorAll('[data-del]').forEach((btn) => {
+        btn.addEventListener('click', () => deleteSlot(btn.getAttribute('data-del')));
+    });
+
+    // Plan panel
+    if (armed && plan && slot) {
+        elements.slotPlan.style.display = 'block';
+        const day = isTomorrow(plan.targetAt) ? ' tomorrow' : '';
+        elements.slotPlanArmed.textContent = `${slot.label} → starts${day} at ${formatSlotClock(plan.targetAt)}`;
+
+        const steps = [];
+        if (plan.windowActive) {
+            steps.push(`Current session ends ${formatSlotClock(plan.currentSessionEnd)}.`);
+        }
+        if (plan.hasIdle) {
+            steps.push(`Stay idle ${formatSlotClock(plan.idleFrom)} → ${formatSlotClock(plan.idleTo)} (don't send anything).`);
+        }
+        if (plan.numFillers > 0) {
+            const fillers = plan.triggerTimes.slice(0, plan.numFillers).map(formatSlotClock).join(', ');
+            steps.push(`Filler window${plan.numFillers > 1 ? 's' : ''} auto-open at ${fillers} — yours to use.`);
+        }
+        steps.push(`Auto-start your window at ${formatSlotClock(plan.targetAt)}.`);
+        elements.slotPlanSteps.innerHTML = steps.map((t) => `<div class="slot-step">• ${escapeHtml(t)}</div>`).join('');
+    } else {
+        elements.slotPlan.style.display = 'none';
+    }
+}
+
+function renderSlotBanner() {
+    if (!elements.slotBanner) return;
+    const { armed, plan, slot } = slotState;
+    const show = armed && plan && plan.inIdleNow;
+    if (show) {
+        elements.slotBannerText.textContent = `⏸ IDLE until ${formatSlotClock(plan.idleTo)} — don't send anything or your ${slot.label} slot shifts.`;
+        elements.slotBanner.style.display = 'flex';
+    } else {
+        elements.slotBanner.style.display = 'none';
+    }
+    if (!isCompactMode) resizeWidget();
+}
+
+// Build an ISO string for the given "HH:MM" at today's date, for display only.
+function setTodayIso(hhmm) {
+    const [h, m] = hhmm.split(':').map(Number);
+    const d = new Date();
+    d.setHours(h, m, 0, 0);
+    return d.toISOString();
+}
+
+function escapeHtml(str) {
+    return String(str).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
 // Start the application
 init();
+loadSlotState();
 window.addEventListener('beforeunload', () => {
     stopAutoUpdate();
     if (countdownInterval) clearInterval(countdownInterval);

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1807,11 +1807,16 @@ async function disarmSlotAction() {
     // The main process pushes the cleared state via onSlotUpdate.
 }
 
-function renderSlots() {
+// Rebuild the slot rows. Skips the rebuild while the user is actively editing a
+// field in the list — otherwise a mid-edit re-render (e.g. the native time
+// input firing 'change' after the first minute digit) would reset the input and
+// swallow further keystrokes. The row already shows what the user typed, so
+// there's nothing to repaint until they move focus away.
+function renderSlotList() {
     if (!elements.slotList) return;
-    const { slots = [], armed, plan, slot } = slotState;
+    if (elements.slotList.contains(document.activeElement)) return;
 
-    // Slot list
+    const { slots = [], armed } = slotState;
     elements.slotList.innerHTML = '';
     slots.forEach((s) => {
         const isArmed = armed && armed.slotId === s.id;
@@ -1837,17 +1842,28 @@ function renderSlots() {
     elements.slotList.querySelectorAll('[data-del]').forEach((btn) => {
         btn.addEventListener('click', () => deleteSlot(btn.getAttribute('data-del')));
     });
-    // Inline edit: rename label (save on blur/Enter) and change time (save on change)
+    // Inline edit: rename label (save on blur/Enter) and change time (save on change).
+    // On blur, re-render once so any state that changed while editing catches up.
     elements.slotList.querySelectorAll('[data-editlabel]').forEach((inp) => {
-        const commit = () => editSlot(inp.getAttribute('data-editlabel'), { label: inp.value.trim() || 'Slot' });
-        inp.addEventListener('blur', commit);
+        inp.addEventListener('blur', () => {
+            editSlot(inp.getAttribute('data-editlabel'), { label: inp.value.trim() || 'Slot' });
+        });
         inp.addEventListener('keydown', (e) => { if (e.key === 'Enter') inp.blur(); });
     });
     elements.slotList.querySelectorAll('[data-edittime]').forEach((inp) => {
-        inp.addEventListener('change', () => {
+        const save = () => {
             if (/^\d{1,2}:\d{2}$/.test(inp.value)) editSlot(inp.getAttribute('data-edittime'), { time: inp.value });
-        });
+        };
+        inp.addEventListener('change', save);
+        inp.addEventListener('blur', save);
     });
+}
+
+function renderSlots() {
+    if (!elements.slotList) return;
+    const { armed, plan, slot } = slotState;
+
+    renderSlotList();
 
     // Plan panel
     if (armed && plan && slot) {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1814,7 +1814,11 @@ async function disarmSlotAction() {
 // there's nothing to repaint until they move focus away.
 function renderSlotList() {
     if (!elements.slotList) return;
-    if (elements.slotList.contains(document.activeElement)) return;
+    // Only skip the rebuild while a text/time FIELD is being edited (rebuilding
+    // would reset it mid-edit). Arm/Disarm/delete buttons don't hold editable
+    // state, so a click on them must still trigger a rebuild to flip the label.
+    const ae = document.activeElement;
+    if (ae && elements.slotList.contains(ae) && ae.matches('[data-editlabel],[data-edittime]')) return;
 
     const { slots = [], armed } = slotState;
     elements.slotList.innerHTML = '';

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1802,6 +1802,11 @@ async function armSlot(slotId) {
     // The main process pushes the fresh plan via onSlotUpdate.
 }
 
+async function disarmSlotAction() {
+    await window.electronAPI.disarmSlot();
+    // The main process pushes the cleared state via onSlotUpdate.
+}
+
 function renderSlots() {
     if (!elements.slotList) return;
     const { slots = [], armed, plan, slot } = slotState;
@@ -1815,13 +1820,19 @@ function renderSlots() {
         row.innerHTML = `
             <input class="slot-item-label" data-editlabel="${s.id}" value="${escapeHtml(s.label)}" maxlength="24" spellcheck="false" title="Click to rename">
             <input type="time" class="slot-item-time" data-edittime="${s.id}" value="${s.time}" title="Click to change time">
-            <button class="slot-arm-btn" data-arm="${s.id}">${isArmed ? 'Armed' : 'Arm'}</button>
+            <button class="slot-arm-btn${isArmed ? ' disarm' : ''}" data-arm="${s.id}">${isArmed ? 'Disarm' : 'Arm'}</button>
             <button class="slot-del-btn" data-del="${s.id}" title="Delete">✕</button>`;
         elements.slotList.appendChild(row);
     });
 
+    // Arm button toggles: if this slot is already armed, clicking disarms it.
     elements.slotList.querySelectorAll('[data-arm]').forEach((btn) => {
-        btn.addEventListener('click', () => armSlot(btn.getAttribute('data-arm')));
+        btn.addEventListener('click', () => {
+            const id = btn.getAttribute('data-arm');
+            const thisArmed = slotState.armed && slotState.armed.slotId === id;
+            if (thisArmed) disarmSlotAction();
+            else armSlot(id);
+        });
     });
     elements.slotList.querySelectorAll('[data-del]').forEach((btn) => {
         btn.addEventListener('click', () => deleteSlot(btn.getAttribute('data-del')));

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -17,7 +17,8 @@ const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const WIDGET_HEIGHT_COLLAPSED = 155;
 const WIDGET_ROW_HEIGHT = 30;
 const GRAPH_HEIGHT = 232;
-const SLOTS_HEIGHT = 200;
+const SLOTS_HEIGHT = 200;      // fallback before the panel has laid out
+const SLOTS_MAX = 520;         // matches .slots-section max-height (512) + margin
 
 // Debug logging — only shows in DevTools (development mode).
 // Regular users won't see verbose logs in production.
@@ -800,7 +801,16 @@ function resizeWidget(bannerVisible) {
         ? EXPAND_OVERHEAD + (extraCount * WIDGET_ROW_HEIGHT)
         : 0;
     const graphOffset = graphVisible ? GRAPH_HEIGHT : 0;
-    const slotsOffset = slotsVisible ? SLOTS_HEIGHT : 0;
+    // Measure the slots panel's actual content height (plan + list + add row)
+    // so the window grows to fit and never clips. Capped by the section's CSS
+    // max-height, beyond which the panel itself scrolls.
+    let slotsOffset = 0;
+    if (slotsVisible && elements.slotsSection) {
+        const measured = elements.slotsSection.scrollHeight || SLOTS_HEIGHT;
+        // Grow to fit the whole panel (+small buffer). Cap keeps it on-screen;
+        // beyond the cap the panel itself scrolls.
+        slotsOffset = Math.min(measured + 10, SLOTS_MAX);
+    }
     const totalHeight = WIDGET_HEIGHT_COLLAPSED + expandedOffset + graphOffset + slotsOffset + bannerOffset;
     window.electronAPI.resizeWindow(totalHeight);
 }
@@ -1769,6 +1779,24 @@ async function deleteSlot(slotId) {
     }
 }
 
+// Edit an existing slot's label and/or time in place.
+async function editSlot(slotId, patch) {
+    const slots = (slotState.slots || []).map((s) =>
+        s.id === slotId ? { ...s, ...patch } : s
+    );
+    // No change? skip the round-trip.
+    const before = (slotState.slots || []).find((s) => s.id === slotId);
+    if (before && ((patch.label === undefined || patch.label === before.label) &&
+        (patch.time === undefined || patch.time === before.time))) {
+        return;
+    }
+    const res = await window.electronAPI.saveSlots(slots);
+    if (res && res.ok) {
+        slotState.slots = res.slots;
+        renderSlots();
+    }
+}
+
 async function armSlot(slotId) {
     await window.electronAPI.armSlot(slotId);
     // The main process pushes the fresh plan via onSlotUpdate.
@@ -1785,8 +1813,8 @@ function renderSlots() {
         const row = document.createElement('div');
         row.className = 'slot-item' + (isArmed ? ' armed' : '');
         row.innerHTML = `
-            <span class="slot-item-label">${escapeHtml(s.label)}</span>
-            <span class="slot-item-time">${formatSlotClock(setTodayIso(s.time))}</span>
+            <input class="slot-item-label" data-editlabel="${s.id}" value="${escapeHtml(s.label)}" maxlength="24" spellcheck="false" title="Click to rename">
+            <input type="time" class="slot-item-time" data-edittime="${s.id}" value="${s.time}" title="Click to change time">
             <button class="slot-arm-btn" data-arm="${s.id}">${isArmed ? 'Armed' : 'Arm'}</button>
             <button class="slot-del-btn" data-del="${s.id}" title="Delete">✕</button>`;
         elements.slotList.appendChild(row);
@@ -1798,6 +1826,17 @@ function renderSlots() {
     elements.slotList.querySelectorAll('[data-del]').forEach((btn) => {
         btn.addEventListener('click', () => deleteSlot(btn.getAttribute('data-del')));
     });
+    // Inline edit: rename label (save on blur/Enter) and change time (save on change)
+    elements.slotList.querySelectorAll('[data-editlabel]').forEach((inp) => {
+        const commit = () => editSlot(inp.getAttribute('data-editlabel'), { label: inp.value.trim() || 'Slot' });
+        inp.addEventListener('blur', commit);
+        inp.addEventListener('keydown', (e) => { if (e.key === 'Enter') inp.blur(); });
+    });
+    elements.slotList.querySelectorAll('[data-edittime]').forEach((inp) => {
+        inp.addEventListener('change', () => {
+            if (/^\d{1,2}:\d{2}$/.test(inp.value)) editSlot(inp.getAttribute('data-edittime'), { time: inp.value });
+        });
+    });
 
     // Plan panel
     if (armed && plan && slot) {
@@ -1805,16 +1844,18 @@ function renderSlots() {
         const day = isTomorrow(plan.targetAt) ? ' tomorrow' : '';
         elements.slotPlanArmed.textContent = `${slot.label} → starts${day} at ${formatSlotClock(plan.targetAt)}`;
 
+        // Steps read chronologically: current session ends → filler windows
+        // run through your waking hours → short pre-dawn idle → target opens.
         const steps = [];
         if (plan.windowActive) {
             steps.push(`Current session ends ${formatSlotClock(plan.currentSessionEnd)}.`);
         }
-        if (plan.hasIdle) {
-            steps.push(`Stay idle ${formatSlotClock(plan.idleFrom)} → ${formatSlotClock(plan.idleTo)} (don't send anything).`);
-        }
         if (plan.numFillers > 0) {
             const fillers = plan.triggerTimes.slice(0, plan.numFillers).map(formatSlotClock).join(', ');
             steps.push(`Filler window${plan.numFillers > 1 ? 's' : ''} auto-open at ${fillers} — yours to use.`);
+        }
+        if (plan.hasIdle) {
+            steps.push(`Idle ${formatSlotClock(plan.idleFrom)} → ${formatSlotClock(plan.idleTo)} — stay off Claude (usually while asleep).`);
         }
         steps.push(`Auto-start your window at ${formatSlotClock(plan.targetAt)}.`);
         elements.slotPlanSteps.innerHTML = steps.map((t) => `<div class="slot-step">• ${escapeHtml(t)}</div>`).join('');

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -40,6 +40,12 @@
                             <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
                         </svg>
                     </button>
+                    <button class="control-btn slots-btn" id="slotsBtn" title="Session Slot Scheduler">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="9" />
+                            <polyline points="12 7 12 12 15 14" />
+                        </svg>
+                    </button>
                     <button class="control-btn minimize-btn" id="minimizeBtn" title="Minimise to System Tray">−</button>
                     <button class="control-btn close-btn" id="closeBtn" title="Exit Application">×</button>
                 </div>
@@ -49,6 +55,11 @@
             <div class="update-banner" id="updateBanner" style="display: none;">
                 <span class="update-banner-text" id="updateBannerText"></span>
                 <button class="update-banner-dismiss" id="updateBannerDismiss" title="Dismiss">✕</button>
+            </div>
+
+            <!-- Slot Guard Banner (shown during the "do not send" idle window) -->
+            <div class="slot-banner" id="slotBanner" style="display: none;">
+                <span class="slot-banner-text" id="slotBannerText"></span>
             </div>
 
             <!-- Loading State -->
@@ -184,6 +195,34 @@
 
                 <div class="graph-section" id="graphSection" style="display: none;">
                     <canvas id="usageChart"></canvas>
+                </div>
+
+                <!-- Session Slot Scheduler panel -->
+                <div class="slots-section" id="slotsSection" style="display: none;">
+                    <div class="slots-header">
+                        <span class="slots-title">Session Slots</span>
+                        <span class="slots-subtitle">Target when your 5-hour window starts</span>
+                    </div>
+
+                    <!-- Live plan for the armed slot -->
+                    <div class="slot-plan" id="slotPlan" style="display: none;">
+                        <div class="slot-plan-row">
+                            <span class="slot-plan-label">Armed</span>
+                            <span class="slot-plan-value" id="slotPlanArmed">—</span>
+                            <button class="slot-disarm-btn" id="slotDisarmBtn" title="Disarm">Disarm</button>
+                        </div>
+                        <div class="slot-plan-steps" id="slotPlanSteps"></div>
+                    </div>
+
+                    <!-- Slot list -->
+                    <div class="slot-list" id="slotList"></div>
+
+                    <!-- Add / edit slot -->
+                    <div class="slot-add-row">
+                        <input type="text" id="slotLabelInput" class="slot-input slot-label-input" placeholder="Label" maxlength="24" spellcheck="false">
+                        <input type="time" id="slotTimeInput" class="slot-input slot-time-input" value="08:00">
+                        <button class="slot-add-btn" id="slotAddBtn">Add</button>
+                    </div>
                 </div>
 
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1589,6 +1589,18 @@ body.theme-light .compact-pct {
     padding-top: 8px;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
     -webkit-app-region: no-drag;
+    max-height: 512px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.slots-section::-webkit-scrollbar {
+    width: 6px;
+}
+
+.slots-section::-webkit-scrollbar-thumb {
+    background: rgba(139, 92, 246, 0.4);
+    border-radius: 3px;
 }
 
 .slots-header {
@@ -1691,20 +1703,57 @@ body.theme-light .compact-pct {
     padding: 4px 7px;
 }
 
+/* Editable label — looks like text until focused */
 .slot-item-label {
     flex: 1;
+    min-width: 0;
     font-size: 11px;
     color: #e0e0e0;
     font-weight: 600;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    font-family: inherit;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 2px 4px;
+    outline: none;
 }
 
+.slot-item-label:hover {
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+.slot-item-label:focus {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(139, 92, 246, 0.6);
+}
+
+/* Editable time */
 .slot-item-time {
     font-size: 11px;
-    color: #a0a0a0;
+    color: #c0c0c0;
+    font-family: inherit;
     font-variant-numeric: tabular-nums;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 2px 2px;
+    outline: none;
+    color-scheme: dark;
+    cursor: pointer;
+}
+
+.slot-item-time:hover {
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+.slot-item-time:focus {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(139, 92, 246, 0.6);
+}
+
+body.theme-light .slot-item-time {
+    color-scheme: light;
+    color: #444;
 }
 
 .slot-arm-btn {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1557,3 +1557,279 @@ body.theme-light .compact-pct {
 .progress-fill.pulse {
     animation: pulse-danger 1.2s ease-in-out infinite;
 }
+
+/* ── Session Slot Scheduler ─────────────────────────────────── */
+.control-btn.active {
+    background: rgba(139, 92, 246, 0.25);
+    color: #c4b5fd;
+}
+
+/* Guard banner (shown during the "do not send" idle window) */
+.slot-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #2a1200;
+    padding: 5px 10px;
+    -webkit-app-region: no-drag;
+    border-bottom: 1px solid rgba(251, 146, 60, 0.35);
+}
+
+.slot-banner-text {
+    font-size: 11px;
+    color: #fbbf24;
+    text-align: center;
+    font-weight: 600;
+    font-family: inherit;
+}
+
+/* Panel */
+.slots-section {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    -webkit-app-region: no-drag;
+}
+
+.slots-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.slots-title {
+    font-size: 12px;
+    font-weight: 700;
+    color: #e0e0e0;
+}
+
+.slots-subtitle {
+    font-size: 10px;
+    color: #808080;
+}
+
+/* Plan panel */
+.slot-plan {
+    background: rgba(139, 92, 246, 0.08);
+    border: 1px solid rgba(139, 92, 246, 0.25);
+    border-radius: 8px;
+    padding: 8px 10px;
+    margin-bottom: 8px;
+}
+
+.slot-plan-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.slot-plan-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #a78bfa;
+    font-weight: 700;
+}
+
+.slot-plan-value {
+    flex: 1;
+    font-size: 11px;
+    color: #ede9fe;
+    font-weight: 600;
+}
+
+.slot-disarm-btn {
+    border: none;
+    background: rgba(255, 255, 255, 0.08);
+    color: #cbd5e1;
+    border-radius: 5px;
+    font-size: 10px;
+    padding: 3px 8px;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.slot-disarm-btn:hover {
+    background: #e74c3c;
+    color: #fff;
+}
+
+.slot-plan-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.slot-step {
+    font-size: 10.5px;
+    color: #b8b8c8;
+    line-height: 1.4;
+}
+
+/* Slot list */
+.slot-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 8px;
+}
+
+.slot-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.slot-item.armed {
+    background: rgba(139, 92, 246, 0.18);
+    border: 1px solid rgba(139, 92, 246, 0.4);
+    padding: 4px 7px;
+}
+
+.slot-item-label {
+    flex: 1;
+    font-size: 11px;
+    color: #e0e0e0;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.slot-item-time {
+    font-size: 11px;
+    color: #a0a0a0;
+    font-variant-numeric: tabular-nums;
+}
+
+.slot-arm-btn {
+    border: none;
+    background: linear-gradient(135deg, #8b5cf6, #6d28d9);
+    color: #fff;
+    border-radius: 5px;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 3px 10px;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.slot-arm-btn:hover {
+    filter: brightness(1.12);
+}
+
+.slot-item.armed .slot-arm-btn {
+    background: rgba(255, 255, 255, 0.15);
+    cursor: default;
+}
+
+.slot-del-btn {
+    border: none;
+    background: transparent;
+    color: #707080;
+    font-size: 12px;
+    cursor: pointer;
+    padding: 0 2px;
+    line-height: 1;
+}
+
+.slot-del-btn:hover {
+    color: #e74c3c;
+}
+
+/* Add-slot row */
+.slot-add-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+.slot-input {
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.05);
+    color: #e0e0e0;
+    border-radius: 6px;
+    font-size: 11px;
+    padding: 4px 8px;
+    font-family: inherit;
+    outline: none;
+}
+
+.slot-input:focus {
+    border-color: rgba(139, 92, 246, 0.6);
+}
+
+.slot-label-input {
+    flex: 1;
+    min-width: 0;
+}
+
+.slot-time-input {
+    width: 92px;
+}
+
+.slot-add-btn {
+    border: none;
+    background: rgba(139, 92, 246, 0.25);
+    color: #c4b5fd;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 5px 12px;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.slot-add-btn:hover {
+    background: rgba(139, 92, 246, 0.4);
+    color: #fff;
+}
+
+/* Light theme */
+body.theme-light .slot-banner {
+    background: #fff4e5;
+    border-bottom-color: rgba(234, 88, 12, 0.3);
+}
+
+body.theme-light .slot-banner-text {
+    color: #c2410c;
+}
+
+body.theme-light .slots-section {
+    border-top-color: rgba(0, 0, 0, 0.08);
+}
+
+body.theme-light .slots-title {
+    color: #2a2a3a;
+}
+
+body.theme-light .slot-plan {
+    background: rgba(139, 92, 246, 0.06);
+}
+
+body.theme-light .slot-plan-value {
+    color: #4c1d95;
+}
+
+body.theme-light .slot-step {
+    color: #555;
+}
+
+body.theme-light .slot-item {
+    background: rgba(0, 0, 0, 0.03);
+}
+
+body.theme-light .slot-item-label {
+    color: #2a2a3a;
+}
+
+body.theme-light .slot-input {
+    background: #fff;
+    border-color: rgba(0, 0, 0, 0.15);
+    color: #2a2a3a;
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1654,12 +1654,14 @@ body.theme-light .compact-pct {
 
 .slot-disarm-btn {
     border: none;
-    background: rgba(255, 255, 255, 0.08);
-    color: #cbd5e1;
+    background: linear-gradient(135deg, #ef4444, #b91c1c);
+    color: #fff;
     border-radius: 5px;
     font-size: 10px;
-    padding: 3px 8px;
+    font-weight: 600;
+    padding: 4px 10px;
     cursor: pointer;
+    flex-shrink: 0;
     font-family: inherit;
 }
 
@@ -1772,9 +1774,14 @@ body.theme-light .slot-item-time {
     filter: brightness(1.12);
 }
 
-.slot-item.armed .slot-arm-btn {
-    background: rgba(255, 255, 255, 0.15);
-    cursor: default;
+/* Armed slot's button becomes a clear, clickable Disarm control */
+.slot-arm-btn.disarm {
+    background: linear-gradient(135deg, #ef4444, #b91c1c);
+    cursor: pointer;
+}
+
+.slot-arm-btn.disarm:hover {
+    filter: brightness(1.12);
 }
 
 .slot-del-btn {

--- a/src/slot-planner.js
+++ b/src/slot-planner.js
@@ -1,0 +1,118 @@
+/**
+ * slot-planner.js
+ *
+ * Pure planning logic for the Session Slot Scheduler.
+ *
+ * The Claude.ai 5-hour usage window opens on the first message sent after the
+ * previous window resets, and always runs a full 5 hours. Staying idle freezes
+ * the boundary. To land a window's start exactly on a target time `Ts`, we
+ * arrange for the previous window to have reset at/before `Ts`, then send the
+ * first message at `Ts`.
+ *
+ * This module is deliberately dependency-free and side-effect-free so it can be
+ * unit-tested with a plain Node script (the project has no test framework).
+ */
+
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+
+/**
+ * Parse an "HH:MM" 24-hour string into { hours, minutes }.
+ * @param {string} slotTime
+ * @returns {{hours:number, minutes:number}}
+ */
+function parseSlotTime(slotTime) {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(slotTime).trim());
+  if (!m) throw new Error(`Invalid slot time: ${slotTime}`);
+  const hours = Number(m[1]);
+  const minutes = Number(m[2]);
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+    throw new Error(`Invalid slot time: ${slotTime}`);
+  }
+  return { hours, minutes };
+}
+
+/**
+ * Return the earliest Date at local `slotTime` that is >= `after`.
+ * @param {string} slotTime - "HH:MM" local
+ * @param {Date} after
+ * @returns {Date}
+ */
+function nextOccurrence(slotTime, after) {
+  const { hours, minutes } = parseSlotTime(slotTime);
+  const candidate = new Date(after);
+  candidate.setHours(hours, minutes, 0, 0);
+  if (candidate.getTime() < after.getTime()) {
+    candidate.setDate(candidate.getDate() + 1);
+  }
+  return candidate;
+}
+
+/**
+ * Determine whether a window is currently active from a resets_at timestamp.
+ * @param {string|number|Date|null|undefined} resetsAt
+ * @param {Date} now
+ * @returns {boolean}
+ */
+function isWindowActive(resetsAt, now) {
+  if (!resetsAt) return false;
+  const end = new Date(resetsAt);
+  if (Number.isNaN(end.getTime())) return false;
+  return end.getTime() > now.getTime();
+}
+
+/**
+ * Compute the alignment plan for an armed slot.
+ *
+ * @param {Object} opts
+ * @param {string} opts.slotTime - target start time, "HH:MM" local
+ * @param {string|number|Date|null} opts.resetsAt - current window reset (or null)
+ * @param {Date} [opts.now] - current time (defaults to new Date())
+ * @returns {{
+ *   currentSessionEnd: Date,   // E — when the active window ends, or `now`
+ *   windowActive: boolean,     // is a window running right now
+ *   targetAt: Date,            // Ts — when the real target window opens
+ *   numFillers: number,        // number of filler windows opened before target
+ *   triggerTimes: Date[],      // every auto-send time, ascending, ending at targetAt
+ *   idleFrom: Date,            // start of the "do not send" guard window
+ *   idleTo: Date,              // end of the guard window (== first trigger)
+ *   hasIdle: boolean           // whether there is a non-zero idle guard window
+ * }}
+ */
+function computePlan({ slotTime, resetsAt, now = new Date() }) {
+  const active = isWindowActive(resetsAt, now);
+  const currentSessionEnd = active ? new Date(resetsAt) : new Date(now);
+
+  const targetAt = nextOccurrence(slotTime, currentSessionEnd);
+  const gap = targetAt.getTime() - currentSessionEnd.getTime();
+  const numFillers = Math.max(0, Math.floor(gap / FIVE_HOURS_MS));
+
+  const firstTriggerMs = targetAt.getTime() - numFillers * FIVE_HOURS_MS;
+
+  const triggerTimes = [];
+  for (let k = numFillers; k >= 0; k--) {
+    triggerTimes.push(new Date(targetAt.getTime() - k * FIVE_HOURS_MS));
+  }
+
+  const idleFrom = new Date(currentSessionEnd);
+  const idleTo = new Date(firstTriggerMs);
+  const hasIdle = idleTo.getTime() > idleFrom.getTime();
+
+  return {
+    currentSessionEnd,
+    windowActive: active,
+    targetAt,
+    numFillers,
+    triggerTimes,
+    idleFrom,
+    idleTo,
+    hasIdle,
+  };
+}
+
+module.exports = {
+  FIVE_HOURS_MS,
+  parseSlotTime,
+  nextOccurrence,
+  isWindowActive,
+  computePlan,
+};

--- a/src/slot-planner.js
+++ b/src/slot-planner.js
@@ -86,15 +86,22 @@ function computePlan({ slotTime, resetsAt, now = new Date() }) {
   const gap = targetAt.getTime() - currentSessionEnd.getTime();
   const numFillers = Math.max(0, Math.floor(gap / FIVE_HOURS_MS));
 
-  const firstTriggerMs = targetAt.getTime() - numFillers * FIVE_HOURS_MS;
+  const startMs = currentSessionEnd.getTime();
 
+  // End placement: run the filler windows back-to-back starting the moment the
+  // current session ends, and push the leftover idle slack to the very end —
+  // the stretch right before the target. For a morning target this lands the
+  // "do not send" idle in the pre-dawn hours (while you're asleep) instead of
+  // wasting your waking daytime, which is what the user actually wants.
   const triggerTimes = [];
-  for (let k = numFillers; k >= 0; k--) {
-    triggerTimes.push(new Date(targetAt.getTime() - k * FIVE_HOURS_MS));
+  for (let k = 0; k < numFillers; k++) {
+    triggerTimes.push(new Date(startMs + k * FIVE_HOURS_MS));
   }
+  triggerTimes.push(new Date(targetAt));
 
-  const idleFrom = new Date(currentSessionEnd);
-  const idleTo = new Date(firstTriggerMs);
+  const lastFillerEnd = startMs + numFillers * FIVE_HOURS_MS;
+  const idleFrom = new Date(lastFillerEnd);
+  const idleTo = new Date(targetAt);
   const hasIdle = idleTo.getTime() > idleFrom.getTime();
 
   return {

--- a/src/slot-sender.js
+++ b/src/slot-sender.js
@@ -1,0 +1,163 @@
+/**
+ * slot-sender.js
+ *
+ * Sends a single throwaway message ("hi") to Claude.ai to open a fresh 5-hour
+ * usage window at a scheduled slot time.
+ *
+ * Why a hidden BrowserWindow + in-page fetch:
+ * Claude.ai sits behind Cloudflare and rejects Electron/Node request headers.
+ * By loading https://claude.ai in a hidden BrowserWindow (which carries the
+ * logged-in session cookies and a spoofed Chrome User-Agent) and running the
+ * fetch() *inside the page context*, the request is same-origin, authenticated,
+ * and indistinguishable from the real web app — the same principle as
+ * fetch-via-window.js, extended to POST.
+ *
+ * The message goes to a single dedicated conversation ("Slot Starter") that is
+ * created once and reused, so the user's chat list is not flooded with "hi"
+ * threads.
+ */
+const { BrowserWindow } = require('electron');
+
+const SLOT_STARTER_NAME = '⏱ Slot Starter';
+const NIL_PARENT_UUID = '00000000-0000-4000-8000-000000000000';
+
+/**
+ * Build the in-page script that (re)creates the dedicated conversation if
+ * needed and posts a completion. Returns a JSON-serialisable result object.
+ *
+ * All values are injected as JSON literals so there is no string-escaping risk.
+ */
+function buildInPageScript({ organizationId, conversationId, name, prompt, parentUuid }) {
+  const cfg = JSON.stringify({ organizationId, conversationId, name, prompt, parentUuid });
+  return `(async () => {
+    const cfg = ${cfg};
+    const org = cfg.organizationId;
+    const base = '/api/organizations/' + org + '/chat_conversations';
+
+    async function createConversation() {
+      const uuid = crypto.randomUUID();
+      const res = await fetch(base, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ uuid, name: cfg.name })
+      });
+      if (!res.ok) {
+        const t = await res.text().catch(() => '');
+        throw new Error('CreateFailed ' + res.status + ' ' + t.slice(0, 160));
+      }
+      return uuid;
+    }
+
+    async function sendCompletion(convId) {
+      const res = await fetch(base + '/' + convId + '/completion', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'accept': 'text/event-stream' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          prompt: cfg.prompt,
+          parent_message_uuid: cfg.parentUuid,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+          attachments: [],
+          files: [],
+          sync_sources: [],
+          rendering_mode: 'messages'
+        })
+      });
+      return res;
+    }
+
+    try {
+      let convId = cfg.conversationId;
+      let created = false;
+      if (!convId) { convId = await createConversation(); created = true; }
+
+      let res = await sendCompletion(convId);
+      // Reused conversation may have been deleted (404/410) — recreate once.
+      if ((res.status === 404 || res.status === 410) && !created) {
+        convId = await createConversation();
+        created = true;
+        res = await sendCompletion(convId);
+      }
+
+      if (!res.ok) {
+        const t = await res.text().catch(() => '');
+        return { ok: false, conversationId: convId, error: 'CompletionFailed ' + res.status + ' ' + t.slice(0, 160) };
+      }
+
+      // Drain the SSE stream so the message is fully accepted before we resolve.
+      try {
+        const reader = res.body && res.body.getReader ? res.body.getReader() : null;
+        if (reader) { while (true) { const { done } = await reader.read(); if (done) break; } }
+        else { await res.text(); }
+      } catch (_) { /* stream end / abort is fine — the message was accepted */ }
+
+      return { ok: true, conversationId: convId, created };
+    } catch (e) {
+      return { ok: false, conversationId: cfg.conversationId || null, error: String(e && e.message || e) };
+    }
+  })();`;
+}
+
+/**
+ * Send the slot-starter message.
+ *
+ * @param {Object} opts
+ * @param {string} opts.organizationId
+ * @param {string|null} opts.conversationId - reused conversation UUID, or null
+ * @param {number} [opts.timeoutMs=30000]
+ * @returns {Promise<{ok:boolean, conversationId:string|null, created?:boolean, error?:string}>}
+ */
+function sendSlotStarter({ organizationId, conversationId = null, timeoutMs = 30000 }) {
+  return new Promise((resolve) => {
+    if (!organizationId) {
+      resolve({ ok: false, conversationId, error: 'Missing organizationId' });
+      return;
+    }
+
+    const win = new BrowserWindow({
+      width: 800,
+      height: 600,
+      show: false,
+      webPreferences: { nodeIntegration: false, contextIsolation: true },
+    });
+
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (!win.isDestroyed()) win.close();
+      resolve(result);
+    };
+
+    const timer = setTimeout(
+      () => finish({ ok: false, conversationId, error: 'Timeout' }),
+      timeoutMs
+    );
+
+    win.webContents.on('did-finish-load', async () => {
+      try {
+        const script = buildInPageScript({
+          organizationId,
+          conversationId,
+          name: SLOT_STARTER_NAME,
+          prompt: 'hi',
+          parentUuid: NIL_PARENT_UUID,
+        });
+        const result = await win.webContents.executeJavaScript(script);
+        finish(result || { ok: false, conversationId, error: 'No result' });
+      } catch (err) {
+        finish({ ok: false, conversationId, error: String(err && err.message || err) });
+      }
+    });
+
+    win.webContents.on('did-fail-load', (_e, code, desc) => {
+      finish({ ok: false, conversationId, error: `LoadFailed ${code} ${desc}` });
+    });
+
+    win.loadURL('https://claude.ai');
+  });
+}
+
+module.exports = { sendSlotStarter, SLOT_STARTER_NAME };

--- a/test/slot-planner.test.js
+++ b/test/slot-planner.test.js
@@ -38,7 +38,7 @@ test('active window ending before target, gap < 5h -> pure idle, single send', (
   assert.strictEqual(plan.idleTo.getTime(), at(BASE, 8, 0).getTime());
 });
 
-test('active window ending 00:00, target 08:00 -> one filler at 03:00', () => {
+test('active window ending 00:00, target 08:00 -> filler at 00:00, idle 05:00-08:00', () => {
   // now 23:00 previous day, window ends 00:00 next day.
   const now = at(BASE, 23, 0, -1);
   const resetsAt = at(BASE, 0, 0).toISOString(); // 00:00 today
@@ -46,11 +46,29 @@ test('active window ending 00:00, target 08:00 -> one filler at 03:00', () => {
 
   assert.strictEqual(plan.numFillers, 1);
   assert.strictEqual(plan.triggerTimes.length, 2);
-  assert.strictEqual(plan.triggerTimes[0].getTime(), at(BASE, 3, 0).getTime());
+  // End placement: filler opens immediately at 00:00, idle sits before target.
+  assert.strictEqual(plan.triggerTimes[0].getTime(), at(BASE, 0, 0).getTime());
   assert.strictEqual(plan.triggerTimes[1].getTime(), at(BASE, 8, 0).getTime());
-  // idle sits at the front: 00:00 -> 03:00
-  assert.strictEqual(plan.idleFrom.getTime(), at(BASE, 0, 0).getTime());
-  assert.strictEqual(plan.idleTo.getTime(), at(BASE, 3, 0).getTime());
+  // idle sits at the end: 05:00 -> 08:00 (pre-dawn)
+  assert.strictEqual(plan.idleFrom.getTime(), at(BASE, 5, 0).getTime());
+  assert.strictEqual(plan.idleTo.getTime(), at(BASE, 8, 0).getTime());
+});
+
+test('idle lands in pre-dawn hours for a morning target (waking hours stay usable)', () => {
+  // Current session ends 11:00 AM, target 06:00 next day. 19h gap, 3 fillers.
+  const now = at(BASE, 10, 0);
+  const resetsAt = at(BASE, 11, 0).toISOString();
+  const plan = computePlan({ slotTime: '06:00', resetsAt, now });
+
+  assert.strictEqual(plan.numFillers, 3);
+  // Fillers run 11:00, 16:00, 21:00 — covering the whole waking day/evening.
+  assert.strictEqual(plan.triggerTimes[0].getTime(), at(BASE, 11, 0).getTime());
+  assert.strictEqual(plan.triggerTimes[1].getTime(), at(BASE, 16, 0).getTime());
+  assert.strictEqual(plan.triggerTimes[2].getTime(), at(BASE, 21, 0).getTime());
+  // Idle is 02:00 -> 06:00 next day (asleep), then the target opens at 06:00.
+  assert.strictEqual(plan.idleFrom.getTime(), at(BASE, 2, 0, 1).getTime());
+  assert.strictEqual(plan.idleTo.getTime(), at(BASE, 6, 0, 1).getTime());
+  assert.strictEqual(plan.triggerTimes[3].getTime(), at(BASE, 6, 0, 1).getTime());
 });
 
 test('no active window, target later today -> idle until target, single send', () => {
@@ -92,14 +110,26 @@ test('armed exactly at target with no window -> immediate single trigger', () =>
   assert.strictEqual(plan.hasIdle, false);
 });
 
-test('fillers are contiguous, each 5h apart, last lands exactly on target', () => {
+test('fillers are contiguous 5h apart; final trigger is the target after the idle', () => {
   const now = at(BASE, 9, 30);
   const plan = computePlan({ slotTime: '08:00', resetsAt: null, now });
   const t = plan.triggerTimes;
-  for (let i = 1; i < t.length; i++) {
+  // The filler triggers (all but the last) are exactly 5h apart.
+  for (let i = 1; i < plan.numFillers; i++) {
     assert.strictEqual(t[i].getTime() - t[i - 1].getTime(), FIVE_HOURS_MS);
   }
-  assert.strictEqual(t[t.length - 1].getTime(), plan.targetAt.getTime());
+  // The last trigger is the target.
+  const last = t[t.length - 1];
+  assert.strictEqual(last.getTime(), plan.targetAt.getTime());
+  // The leftover idle slack is always less than a full window.
+  const idleMs = plan.idleTo.getTime() - plan.idleFrom.getTime();
+  assert.ok(idleMs >= 0 && idleMs < FIVE_HOURS_MS);
+  // Idle begins exactly when the last filler ends (its start + 5h) and ends at target.
+  if (plan.numFillers > 0) {
+    const lastFillerStart = t[plan.numFillers - 1].getTime();
+    assert.strictEqual(plan.idleFrom.getTime(), lastFillerStart + FIVE_HOURS_MS);
+  }
+  assert.strictEqual(plan.idleTo.getTime(), plan.targetAt.getTime());
 });
 
 console.log(`\n${passed} tests passed.`);

--- a/test/slot-planner.test.js
+++ b/test/slot-planner.test.js
@@ -1,0 +1,105 @@
+/**
+ * Plain-Node test for the slot planner. Run with: node test/slot-planner.test.js
+ * Exits non-zero on the first failure.
+ */
+const assert = require('assert');
+const { computePlan, FIVE_HOURS_MS } = require('../src/slot-planner');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ok - ${name}`);
+}
+
+// Helper: build a local Date for "today" relative to a base date at HH:MM.
+function at(base, h, m = 0, dayOffset = 0) {
+  const d = new Date(base);
+  d.setHours(h, m, 0, 0);
+  d.setDate(d.getDate() + dayOffset);
+  return d;
+}
+
+const BASE = new Date(2026, 6, 11, 9, 0, 0, 0); // 2026-07-11 09:00 local
+
+test('active window ending before target, gap < 5h -> pure idle, single send', () => {
+  // Current window ends 05:00, target 08:00. now = 04:00 (window active).
+  const now = at(BASE, 4, 0);
+  const resetsAt = at(BASE, 5, 0).toISOString();
+  const plan = computePlan({ slotTime: '08:00', resetsAt, now });
+
+  assert.strictEqual(plan.windowActive, true);
+  assert.strictEqual(plan.numFillers, 0);
+  assert.strictEqual(plan.targetAt.getTime(), at(BASE, 8, 0).getTime());
+  assert.strictEqual(plan.triggerTimes.length, 1);
+  assert.strictEqual(plan.triggerTimes[0].getTime(), at(BASE, 8, 0).getTime());
+  assert.strictEqual(plan.hasIdle, true);
+  assert.strictEqual(plan.idleFrom.getTime(), at(BASE, 5, 0).getTime());
+  assert.strictEqual(plan.idleTo.getTime(), at(BASE, 8, 0).getTime());
+});
+
+test('active window ending 00:00, target 08:00 -> one filler at 03:00', () => {
+  // now 23:00 previous day, window ends 00:00 next day.
+  const now = at(BASE, 23, 0, -1);
+  const resetsAt = at(BASE, 0, 0).toISOString(); // 00:00 today
+  const plan = computePlan({ slotTime: '08:00', resetsAt, now });
+
+  assert.strictEqual(plan.numFillers, 1);
+  assert.strictEqual(plan.triggerTimes.length, 2);
+  assert.strictEqual(plan.triggerTimes[0].getTime(), at(BASE, 3, 0).getTime());
+  assert.strictEqual(plan.triggerTimes[1].getTime(), at(BASE, 8, 0).getTime());
+  // idle sits at the front: 00:00 -> 03:00
+  assert.strictEqual(plan.idleFrom.getTime(), at(BASE, 0, 0).getTime());
+  assert.strictEqual(plan.idleTo.getTime(), at(BASE, 3, 0).getTime());
+});
+
+test('no active window, target later today -> idle until target, single send', () => {
+  const now = at(BASE, 7, 10);
+  const plan = computePlan({ slotTime: '08:00', resetsAt: null, now });
+
+  assert.strictEqual(plan.windowActive, false);
+  assert.strictEqual(plan.numFillers, 0);
+  assert.strictEqual(plan.targetAt.getTime(), at(BASE, 8, 0).getTime());
+  assert.strictEqual(plan.triggerTimes.length, 1);
+  assert.strictEqual(plan.hasIdle, true);
+});
+
+test('no active window, target already passed today -> tomorrow', () => {
+  const now = at(BASE, 9, 30);
+  const plan = computePlan({ slotTime: '08:00', resetsAt: null, now });
+
+  assert.strictEqual(plan.targetAt.getTime(), at(BASE, 8, 0, 1).getTime());
+  // gap ~22.5h -> floor(22.5/5)=4 fillers
+  assert.strictEqual(plan.numFillers, 4);
+  assert.strictEqual(plan.triggerTimes.length, 5);
+});
+
+test('past resetsAt is treated as no active window', () => {
+  const now = at(BASE, 9, 30);
+  const resetsAt = at(BASE, 6, 0).toISOString(); // already passed
+  const plan = computePlan({ slotTime: '13:00', resetsAt, now });
+
+  assert.strictEqual(plan.windowActive, false);
+  assert.strictEqual(plan.currentSessionEnd.getTime(), now.getTime());
+  assert.strictEqual(plan.targetAt.getTime(), at(BASE, 13, 0).getTime());
+});
+
+test('armed exactly at target with no window -> immediate single trigger', () => {
+  const now = at(BASE, 8, 0);
+  const plan = computePlan({ slotTime: '08:00', resetsAt: null, now });
+  assert.strictEqual(plan.numFillers, 0);
+  assert.strictEqual(plan.targetAt.getTime(), now.getTime());
+  assert.strictEqual(plan.hasIdle, false);
+});
+
+test('fillers are contiguous, each 5h apart, last lands exactly on target', () => {
+  const now = at(BASE, 9, 30);
+  const plan = computePlan({ slotTime: '08:00', resetsAt: null, now });
+  const t = plan.triggerTimes;
+  for (let i = 1; i < t.length; i++) {
+    assert.strictEqual(t[i].getTime() - t[i - 1].getTime(), FIVE_HOURS_MS);
+  }
+  assert.strictEqual(t[t.length - 1].getTime(), plan.targetAt.getTime());
+});
+
+console.log(`\n${passed} tests passed.`);


### PR DESCRIPTION
## Session Slot Scheduler — target when your 5‑hour window starts

Claude's usage window is a rolling 5 hours that opens on your **first message after the previous window resets**, and always runs the full 5 hours. Because most people just message whenever, their window boundaries drift to arbitrary times (9 AM–2 PM, 2–7 PM, 7 PM–12 AM…) and never line up with the hours they actually want to work.

This feature lets you **target specific start times** (e.g. "start my slot at 8 AM") and have the widget place the window there automatically — by sending a single throwaway "hi" at the right moment to claim the window.

Opt‑in via a new clock icon in the toolbar; if you never open it, nothing changes.

### What it does
- **Named slots** — define target start times (defaults: Early 06:00, Morning 08:00, Afternoon 13:00). Label and time are editable inline; add/delete freely.
- **Arm one** — the widget computes and shows a live plan: when your current session ends, the exact "do not send" idle window, any optional filler windows, and the auto‑start time. One prominent red **Disarm** toggles it off.
- **Smart placement** — filler windows run back‑to‑back through your waking hours and the unavoidable idle slack is pushed to the pre‑dawn hours (while you're asleep), so daytime stays usable.
- **Auto‑send** — at each trigger the widget posts "hi" to one dedicated, reused "⏱ Slot Starter" conversation, so your chat history isn't flooded. Claude's reply is irrelevant; posting is what claims the window.
- **Guard** — during the idle window it shows a banner and fires a desktop notification so you don't accidentally start a misaligned window.
- **Robust** — re‑plans every 15 s and on each usage refresh; detects a broken plan and re‑plans; handles missed triggers after the app was closed; falls back to a "send hi yourself" notification if the API call fails.

### How the send works (no CLI / API key)
It reuses the widget's existing logged‑in claude.ai session: a hidden `BrowserWindow` on `https://claude.ai` runs a `fetch()` **inside the page context** (same‑origin, carries cookies, passes Cloudflare) to claude.ai's own web endpoints — create/reuse a conversation, then POST a completion. This mirrors the existing `fetch-via-window.js` GET approach, extended to POST. Verified end‑to‑end against a live account.

### Implementation
- `src/slot-planner.js` — pure, dependency‑free planning maths, with a plain‑Node test suite (`test/slot-planner.test.js`, 8 cases).
- `src/slot-sender.js` — the in‑page send (create/reuse the dedicated conversation).
- `main.js` — slot CRUD + arm/disarm IPC, a 15 s scheduler, plan recompute on refresh, notifications. Also sets `app.setAppUserModelId` on Windows so desktop toasts actually render.
- `preload.js` / renderer — the Slots panel, live plan, guard banner, inline editing.
- `docs/plans/2026-07-11-session-slot-scheduler-design.md` — full design writeup.

No new runtime dependencies. Cross‑platform (Windows/macOS/Linux) — the notification AUMID fix is Windows‑guarded.

### Caveat
The send uses claude.ai's private web endpoints, so if Anthropic changes them the POST could fail — in which case it falls back to a desktop notification prompting you to send "hi" yourself, so a slot is never silently missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
