### PR TITLE
add Fable usage meter

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,9 +58,19 @@ let weeklyTray = null;   // Tray icon for Weekly usage
 
 const WIDGET_WIDTH = process.platform === 'darwin' ? 590 : 560;
 const WIDGET_HEIGHT = 155;
+const COMPACT_WIDTH = 290;
+const COMPACT_HEIGHT = 105;
+const COMPACT_ROW_HEIGHT = 28; // extra height needed for the optional Fable row
 const HISTORY_RETENTION_DAYS = 8;
 const CHART_DAYS = 7;
 const MAX_HISTORY_SAMPLES = 10000; // Cap total samples to prevent unbounded growth
+
+// Compact mode always shows Session + Weekly; grows by one row when the
+// account has a scoped Fable weekly limit (data.seven_day_fable).
+function getCompactHeight() {
+  const data = store.get('latestUsageData');
+  return data?.seven_day_fable ? COMPACT_HEIGHT + COMPACT_ROW_HEIGHT : COMPACT_HEIGHT;
+}
 
 function storeUsageHistory(data) {
   // Skip write if the session is invalid — a live session always has resets_at timestamps.
@@ -82,6 +92,7 @@ function storeUsageHistory(data) {
     weekly: data.seven_day?.utilization || 0,
     sonnet: data.seven_day_sonnet?.utilization || 0,
     opus: data.seven_day_opus?.utilization || 0,
+    fable: data.seven_day_fable?.utilization || 0,
     cowork: data.seven_day_cowork?.utilization || 0,
     design: data.seven_day_omelette?.utilization || 0,
     oauthApps: data.seven_day_oauth_apps?.utilization || 0,
@@ -995,8 +1006,8 @@ ipcMain.on('show-notification', (event, { title, body }) => {
 ipcMain.on('set-compact-mode', (event, compact) => {
   if (mainWindow) {
     const bounds = mainWindow.getBounds();
-    const width = compact ? 290 : WIDGET_WIDTH;
-    const height = compact ? 105 : WIDGET_HEIGHT;
+    const width = compact ? COMPACT_WIDTH : WIDGET_WIDTH;
+    const height = compact ? getCompactHeight() : WIDGET_HEIGHT;
     mainWindow.setBounds({ x: bounds.x, y: bounds.y, width, height });
   }
 });
@@ -1343,6 +1354,23 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
 
   const data = usageResult.value;
 
+  // Some accounts report per-model weekly limits (e.g. Fable) via the generic
+  // `limits` array instead of a dedicated `seven_day_<model>` field. Surface
+  // those as synthetic seven_day_<model> entries so the rest of the pipeline
+  // (history storage, extra rows, chart) can treat them like Sonnet/Opus.
+  if (Array.isArray(data.limits)) {
+    for (const limit of data.limits) {
+      const modelName = limit?.scope?.model?.display_name;
+      if (limit.kind === 'weekly_scoped' && modelName) {
+        const modelKey = modelName.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+        data[`seven_day_${modelKey}`] = {
+          utilization: limit.percent,
+          resets_at: limit.resets_at,
+        };
+      }
+    }
+  }
+
   // Merge overage spending data into data.extra_usage
   if (overageResult.status === 'fulfilled' && overageResult.value) {
     const overage = overageResult.value;
@@ -1391,6 +1419,12 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
 
   // Update tray icon with current usage data
   updateTrayIcon(data);
+
+  // Keep the compact window sized correctly if the Fable row just appeared/disappeared
+  if (mainWindow && !mainWindow.isDestroyed() && store.get('settings.compactMode', false)) {
+    const bounds = mainWindow.getBounds();
+    mainWindow.setBounds({ x: bounds.x, y: bounds.y, width: COMPACT_WIDTH, height: getCompactHeight() });
+  }
 
   // Re-assert always-on-top after hidden BrowserWindows from fetchViaWindow
   // are destroyed — creating/destroying BrowserWindows can temporarily disrupt

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -99,6 +99,9 @@ const elements = {
     compactSessionPct: document.getElementById('compactSessionPct'),
     compactWeeklyFill: document.getElementById('compactWeeklyFill'),
     compactWeeklyPct: document.getElementById('compactWeeklyPct'),
+    compactFableRow: document.getElementById('compactFableRow'),
+    compactFableFill: document.getElementById('compactFableFill'),
+    compactFablePct: document.getElementById('compactFablePct'),
     compactSettingsOverlay: document.getElementById('compactSettingsOverlay'),
     closeCompactSettingsBtn: document.getElementById('closeCompactSettingsBtn')
 };
@@ -548,6 +551,7 @@ function formatCurrency(amountCents, currencyCode) {
 const EXTRA_ROW_CONFIG = {
     seven_day_sonnet: { label: 'Sonnet (7d)', color: 'sonnet' },
     seven_day_opus: { label: 'Opus (7d)', color: 'opus' },
+    seven_day_fable: { label: 'Fable (7d)', color: 'fable' },
     seven_day_cowork: { label: 'Cowork (7d)', color: 'cowork' },
     seven_day_omelette: { label: 'Design (7d)', color: 'design' },
     seven_day_oauth_apps: { label: 'OAuth Apps (7d)', color: 'oauth' },
@@ -923,6 +927,19 @@ function updateCompactBars(data) {
     elements.compactWeeklyFill.className = 'compact-bar-fill weekly';
     if (weeklyPct >= dangerThreshold) elements.compactWeeklyFill.classList.add('danger');
     else if (weeklyPct >= warnThreshold) elements.compactWeeklyFill.classList.add('warning');
+
+    // Fable — only shown when the account has a scoped Fable weekly limit
+    if (data.seven_day_fable) {
+        const fablePct = Math.min(Math.max(data.seven_day_fable.utilization || 0, 0), 100);
+        elements.compactFableRow.style.display = '';
+        elements.compactFableFill.style.width = `${fablePct}%`;
+        elements.compactFablePct.textContent = `${Math.round(fablePct)}%`;
+        elements.compactFableFill.className = 'compact-bar-fill fable';
+        if (fablePct >= dangerThreshold) elements.compactFableFill.classList.add('danger');
+        else if (fablePct >= warnThreshold) elements.compactFableFill.classList.add('warning');
+    } else {
+        elements.compactFableRow.style.display = 'none';
+    }
 }
 // Persist compact mode setting without touching the rest of settings — debounced
 let _saveCompactTimer = null;
@@ -1268,6 +1285,7 @@ function renderChart(history) {
 
     const showSonnet = isExpanded && !!latestUsageData?.seven_day_sonnet;
     const showOpus = isExpanded && !!latestUsageData?.seven_day_opus;
+    const showFable = isExpanded && !!latestUsageData?.seven_day_fable;
     const showCowork = isExpanded && !!latestUsageData?.seven_day_cowork;
     const showDesign = isExpanded && !!latestUsageData?.seven_day_omelette;
     const showOAuthApps = isExpanded && !!latestUsageData?.seven_day_oauth_apps;
@@ -1276,6 +1294,7 @@ function renderChart(history) {
         const values = [entry.session, entry.weekly];
         if (showSonnet) values.push(entry.sonnet || 0);
         if (showOpus) values.push(entry.opus || 0);
+        if (showFable) values.push(entry.fable || 0);
         if (showCowork) values.push(entry.cowork || 0);
         if (showDesign) values.push(entry.design || 0);
         if (showOAuthApps) values.push(entry.oauthApps || 0);
@@ -1333,6 +1352,23 @@ function renderChart(history) {
                 label: 'Opus',
                 data: history.map((entry) => ({ x: entry.timestamp, y: entry.opus || 0 })),
                 borderColor: '#f59e0b',
+                backgroundColor: 'transparent',
+                borderWidth: 2,
+                stepped: true,
+                pointRadius: 0,
+                pointHoverRadius: 3,
+                pointHitRadius: 10
+            });
+        }
+    }
+
+    if (showFable) {
+        const fableData = history.map((entry) => entry.fable || 0);
+        if (fableData.some((value) => value > 0)) {
+            datasets.push({
+                label: 'Fable',
+                data: history.map((entry) => ({ x: entry.timestamp, y: entry.fable || 0 })),
+                borderColor: '#c026d3',
                 backgroundColor: 'transparent',
                 borderWidth: 2,
                 stepped: true,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -214,6 +214,15 @@
                             </div>
                         </div>
                     </div>
+                    <div class="compact-row" id="compactFableRow" style="display: none;">
+                        <span class="compact-label">Fable</span>
+                        <div class="compact-bar-wrap">
+                            <div class="compact-bar-bg">
+                                <div class="compact-bar-fill fable" id="compactFableFill" style="width: 0%"></div>
+                                <span class="compact-pct" id="compactFablePct">0%</span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -659,6 +659,11 @@ body.theme-light .graph-btn.active {
     box-shadow: 0 0 10px rgba(244, 63, 94, 0.3);
 }
 
+.progress-fill.fable {
+    background: linear-gradient(90deg, #c026d3 0%, #e879f9 100%);
+    box-shadow: 0 0 10px rgba(192, 38, 211, 0.3);
+}
+
 .progress-fill.cowork {
     background: linear-gradient(90deg, #06b6d4 0%, #22d3ee 100%);
     box-shadow: 0 0 10px rgba(6, 182, 212, 0.3);
@@ -727,6 +732,10 @@ body.theme-light .graph-btn.active {
 
 .timer-progress.sonnet {
     stroke: #f43f5e;
+}
+
+.timer-progress.fable {
+    stroke: #c026d3;
 }
 
 .timer-progress.cowork {
@@ -1486,6 +1495,10 @@ body.compact-mode .title {
 
 .compact-bar-fill.weekly {
     background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%);
+}
+
+.compact-bar-fill.fable {
+    background: linear-gradient(90deg, #c026d3 0%, #e879f9 100%);
 }
 
 .compact-bar-fill.warning {


### PR DESCRIPTION
Surface the per-model weekly Fable limit that the Claude API now reports via the generic `limits` array (kind: weekly_scoped, scope.model.display_name) instead of a dedicated seven_day_<model> field.

- main.js: map weekly_scoped model limits into synthetic seven_day_<model>
  entries so the existing pipeline treats Fable like Sonnet/Opus; store Fable
  in usage history; grow the compact window by one row when a Fable limit exists
- app.js: add Fable to the expanded rows, history chart, and compact-mode bars
- index.html: add the compact-mode Fable row (hidden unless data is present)
- styles.css: Fable bar/timer colors