### PR TITLE
fix: fall back to plain-text session key when decryption fails (silent logout)

### DIFF
--- a/main.js
+++ b/main.js
@@ -929,25 +929,29 @@ function updateTrayIcon(usageData) {
 }
 
 
-// IPC Handlers
-ipcMain.handle('get-credentials', () => {
-  let sessionKey = null;
-  // Try safeStorage first (OS keychain)
+// Retrieve the stored session key, decrypting if it was saved encrypted.
+// If decryption fails, the stored value predates encryption being available
+// (plain text in sessionKey_encrypted) — return it as-is instead of null,
+// which silently logged the user out (0% / "Not started").
+function getStoredSessionKey(context = '') {
   if (safeStorage.isEncryptionAvailable()) {
     const encrypted = store.get('sessionKey_encrypted');
-    if (encrypted) {
-      try {
-        sessionKey = safeStorage.decryptString(Buffer.from(encrypted, 'base64'));
-      } catch (err) {
-        console.error('[Keychain] Failed to decrypt session key:', err.message);
-      }
+    if (!encrypted) return store.get('sessionKey') || null;
+    try {
+      return safeStorage.decryptString(Buffer.from(encrypted, 'base64'));
+    } catch (err) {
+      console.error(`[Keychain] Failed to decrypt session key${context}:`, err.message);
+      return encrypted;
     }
-  } else {
-    // Fallback: plain storage (legacy or safeStorage unavailable)
-    sessionKey = store.get('sessionKey');
   }
+  // Fallback: plain storage (legacy or safeStorage unavailable)
+  return store.get('sessionKey') || null;
+}
+
+// IPC Handlers
+ipcMain.handle('get-credentials', () => {
   return {
-    sessionKey,
+    sessionKey: getStoredSessionKey(),
     organizationId: store.get('organizationId')
   };
 });
@@ -1450,19 +1454,7 @@ function isNewerPreRelease(remote, local) {
 
 ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
   // Use the same credential retrieval logic as get-credentials
-  let sessionKey = null;
-  if (safeStorage.isEncryptionAvailable()) {
-    const encrypted = store.get('sessionKey_encrypted');
-    if (encrypted) {
-      try {
-        sessionKey = safeStorage.decryptString(Buffer.from(encrypted, 'base64'));
-      } catch (err) {
-        console.error('[Keychain] Failed to decrypt session key:', err.message);
-      }
-    }
-  } else {
-    sessionKey = store.get('sessionKey');
-  }
+  const sessionKey = getStoredSessionKey();
 
   const organizationId = store.get('organizationId');
 
@@ -1645,19 +1637,7 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
 // App lifecycle
 app.whenReady().then(async () => {
   // Restore session cookie if we have stored credentials
-  let sessionKey = null;
-  if (safeStorage.isEncryptionAvailable()) {
-    const encrypted = store.get('sessionKey_encrypted');
-    if (encrypted) {
-      try {
-        sessionKey = safeStorage.decryptString(Buffer.from(encrypted, 'base64'));
-      } catch (err) {
-        console.error('[Keychain] Failed to decrypt session key on startup:', err.message);
-      }
-    }
-  } else {
-    sessionKey = store.get('sessionKey');
-  }
+  const sessionKey = getStoredSessionKey(' on startup');
 
   if (sessionKey) {
     await setSessionCookie(sessionKey);


### PR DESCRIPTION
Extracts the session-key fix flagged in #74 review as "a real bug" in single-account session handling.

**Bug**
- Keys saved before OS encryption was available are stored plain text
- `decryptString` then throws on every read; key becomes `null`
- User silently logged out: 0% / "Not started"

**Fix**
- New `getStoredSessionKey()` helper; `get-credentials`, `fetch-usage-data`, and startup share it (replaces 3 inline copies)
- On decryption failure: return raw stored value instead of `null`
- Encryption available but only legacy plain `sessionKey` present: use it (key saved while DPAPI was unavailable)

**Testing**
- `node --check` passes
- Same fallback logic has run in my fork since May; this is the clean single-account version
- Net −20 lines