### PR TITLE
fix: deny renderer permission requests (camera/mic prompt on login) + patch dev-dependency advisories

### DIFF
--- a/main.js
+++ b/main.js
@@ -1644,6 +1644,46 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
 
 // App lifecycle
 app.whenReady().then(async () => {
+  // SECURITY: refuse every renderer permission request before any window can
+  // ask for one.
+  //
+  // The widget needs no device or ambient capability whatsoever, but it does
+  // load claude.ai — in the login window, and in the hidden fetch windows in
+  // src/fetch-via-window.js — and claude.ai asks for the microphone for voice
+  // input. With no handler registered, that request fell through to Electron's
+  // default and reached the user as an OS prompt for the camera and mic, which
+  // this app has no business asking for.
+  //
+  // Everything the app genuinely does bypasses this handler already, so
+  // denying the lot costs nothing:
+  //   - notifications come from main via new Notification(), not the renderer
+  //   - external links go through shell.openExternal (see 'open-external'),
+  //     not the openExternal permission
+  //   - WebAuthn/passkey sign-in is not gated by this handler, so SSO logins
+  //     into claude.ai keep working
+  //
+  // All windows share session.defaultSession (no custom partitions), so this
+  // single registration covers main, login and the fetch windows.
+  const denyPermission = (permission, source) => {
+    debugLog(`[Security] Denied "${permission}" requested by ${source || 'unknown origin'}`);
+    return false;
+  };
+
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
+    callback(denyPermission(permission, details?.requestingUrl || webContents?.getURL?.()));
+  });
+
+  session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
+    // Kept in agreement with the request handler above, so a page's
+    // navigator.permissions.query() is told the same thing it would be told
+    // if it actually asked.
+    return denyPermission(permission, requestingOrigin);
+  });
+
+  // USB/HID/Serial are chosen through a separate path that the permission
+  // handler above never sees. Nothing in this app uses them.
+  session.defaultSession.setDevicePermissionHandler(() => false);
+
   // Restore session cookie if we have stored credentials
   let sessionKey = null;
   if (safeStorage.isEncryptionAvailable()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -244,9 +244,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -984,16 +984,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-from": {
@@ -1467,9 +1467,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1881,9 +1881,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1932,9 +1932,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2110,9 +2110,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2781,9 +2781,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3537,9 +3537,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3676,9 +3676,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
### What this does

Registers a deny-all permission policy on `session.defaultSession` before any window is created, and clears the four `npm audit` advisories.

**Permissions.** `main.js` currently registers no `setPermissionRequestHandler` or `setPermissionCheckHandler` anywhere. The app loads claude.ai in the login window (`main.js`, `openLoginWindow`) and in the hidden fetch windows in `src/fetch-via-window.js`, and claude.ai asks for the microphone for its voice-input feature. With no handler registered, that request falls through to Electron's default and reaches the user as an OS prompt for the camera and microphone. I hit this on a normal login and had to decline it manually — a usage widget has no business asking for either.

This adds `setPermissionRequestHandler` and `setPermissionCheckHandler`, both refusing everything, plus `setDevicePermissionHandler` for USB/HID/Serial, which travel a separate path the permission handler never sees. All windows share `defaultSession` with no custom partition, so the single registration covers main, login and fetch.

Deny-all is safe because nothing the app actually does goes through this handler:

- notifications are raised in main via `new Notification()` behind the `show-notification` channel, not the renderer permission
- external links go through `shell.openExternal` behind `open-external`
- WebAuthn/passkey sign-in is not gated by this handler, so SSO logins into claude.ai still work

Denials go through `debugLog`, so they're invisible in normal use but recoverable with `DEBUG_LOG=1`. (Worth noting for anyone testing: Electron intercepts `--debug` itself and refuses to start, so the env var is the working switch.)

**Dependencies.** `npm audit` reported 4 advisories (3 high, 1 moderate) in `brace-expansion`, `fast-uri`, `tar` and `undici`. All four are devDependency transitives of the electron-builder toolchain, so they never ship inside the packaged app — the exposure was to the build machine, not to installed users. `npm audit fix` (no `--force`) clears all four with patch bumps only, and `package.json` is untouched. `npm audit` now reports 0.

`package-lock.json` is included because it's tracked deliberately for reproducible builds (682561b).

### Testing

Windows 11, run from source and as a packaged build.

Verified in the running app rather than by inspection:

- `getUserMedia({audio})` and `getUserMedia({video})` both reject with `NotAllowedError`
- geolocation rejects with code 1, and `navigator.permissions.query` returns `"denied"` — so the check handler and the request handler can't disagree
- the denials appear in the debug log
- usage data still fetches normally, confirming the hidden fetch windows still work under the hardened session
- a full `npm run build:win` succeeds on the updated lockfile

### Notes

Independent of my other two PRs — no dependency in either direction.
