### PR TITLE
feat: promote Fable to a primary row above the expansion

### DIFF
--- a/main.js
+++ b/main.js
@@ -101,6 +101,7 @@ const COMPACT_HEIGHT = 105;
 const COMPACT_ROW_HEIGHT = 28; // extra height per optional row (Fable, Spend)
 const COMPACT_CHEVRON_HEIGHT = 15; // the always-visible spend toggle chevron
 const COMPACT_BANNER_HEIGHT = 28; // matches BANNER_HEIGHT in the renderer's resizeWidget()
+const FABLE_ROW_HEIGHT = 34; // matches FABLE_ROW_HEIGHT in the renderer's app.js
 const HISTORY_RETENTION_DAYS = 8;
 
 // Compact mode always shows Session + Weekly plus the spend chevron; grows by
@@ -117,6 +118,20 @@ function getCompactHeight() {
   if (store.get('settings.compactSpendOpen', false)) height += COMPACT_ROW_HEIGHT;
   if (store.get('updateBannerVisible', false)) height += COMPACT_BANNER_HEIGHT;
   return height;
+}
+
+// Normal mode's collapsed height. WIDGET_HEIGHT covers Session + Weekly; the
+// Fable primary row only exists on accounts that have that scoped weekly
+// limit, so it is added the same way getCompactHeight() adds its own Fable
+// row. Kept beside it so the two can't drift apart.
+//
+// The renderer recomputes the full height itself in resizeWidget() (which also
+// accounts for the expansion, graph and update banner). This is the main
+// process's answer for the two moments it sizes the window without asking:
+// first paint, and returning from compact mode.
+function getNormalHeight() {
+  const data = store.get('latestUsageData');
+  return WIDGET_HEIGHT + (data?.seven_day_fable ? FABLE_ROW_HEIGHT : 0);
 }
 const CHART_DAYS = 7;
 const MAX_HISTORY_SAMPLES = 10000; // Cap total samples to prevent unbounded growth
@@ -277,14 +292,17 @@ function showMainWindowSmart() {
 }
 
 function createMainWindow() {
+  // Size the first paint for the Fable row too, so accounts that have the
+  // limit don't get a visible resize a moment after launch.
+  const startHeight = getNormalHeight();
   let savedPosition = store.get('windowPosition');
-  if (savedPosition && !isPositionOnScreen(savedPosition.x, savedPosition.y, WIDGET_WIDTH, WIDGET_HEIGHT)) {
+  if (savedPosition && !isPositionOnScreen(savedPosition.x, savedPosition.y, WIDGET_WIDTH, startHeight)) {
     debugLog('[Window] Saved position', savedPosition, 'is off-screen on current display setup; centering instead');
     savedPosition = null;
   }
   const windowOptions = {
     width: WIDGET_WIDTH,
-    height: WIDGET_HEIGHT,
+    height: startHeight,
     frame: false,
     transparent: true,
     alwaysOnTop: true,
@@ -1130,7 +1148,7 @@ ipcMain.on('set-compact-mode', (event, compact) => {
   if (mainWindow) {
     const bounds = mainWindow.getBounds();
     const width = compact ? COMPACT_WIDTH : WIDGET_WIDTH;
-    const height = compact ? getCompactHeight() : WIDGET_HEIGHT;
+    const height = compact ? getCompactHeight() : getNormalHeight();
     mainWindow.setBounds({ x: bounds.x, y: bounds.y, width, height });
   }
 });

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -15,6 +15,10 @@ let isFetching = false;       // in-flight guard — prevents overlapping fetchU
 const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const WIDGET_HEIGHT_COLLAPSED = 155;
 const WIDGET_ROW_HEIGHT = 30;
+// Height the optional Fable primary row adds: .usage-section is 32px tall with
+// a 2px bottom margin. Must match FABLE_ROW_HEIGHT in main.js, which sizes the
+// same window from the main process.
+const FABLE_ROW_HEIGHT = 34;
 const GRAPH_HEIGHT = 232;
 
 // Elapsed-time ring thresholds (session/weekly/extra-row countdown circles).
@@ -65,6 +69,13 @@ const elements = {
     weeklyTimer: document.getElementById('weeklyTimer'),
     weeklyTimeText: document.getElementById('weeklyTimeText'),
     weeklyResetsAt: document.getElementById('weeklyResetsAt'),
+
+    fableSection: document.getElementById('fableSection'),
+    fablePercentage: document.getElementById('fablePercentage'),
+    fableProgress: document.getElementById('fableProgress'),
+    fableTimer: document.getElementById('fableTimer'),
+    fableTimeText: document.getElementById('fableTimeText'),
+    fableResetsAt: document.getElementById('fableResetsAt'),
 
     sessionResetsAt: document.getElementById('sessionResetsAt'),
 
@@ -588,11 +599,18 @@ function formatCurrency(amountCents, currencyCode) {
   return sym ? `${sym}${amount}` : `${amount} ${currencyCode || 'USD'}`;
 }
 
+// Usage keys that have their own always-visible row in the main widget body
+// rather than a row inside the expansion. These must be excluded from BOTH
+// EXTRA_ROW_CONFIG below and the scoped-model registration in
+// normalizeUsageData(), or the same limit renders twice — once as a primary
+// row and once as a generic "scoped" row in the expansion.
+const PRIMARY_ROW_KEYS = new Set(['seven_day_fable']);
+
 // Extra row label mapping for API fields
 const EXTRA_ROW_CONFIG = {
     seven_day_sonnet: { label: 'Sonnet (7d)', color: 'sonnet' },
     seven_day_opus: { label: 'Opus (7d)', color: 'opus' },
-    seven_day_fable: { label: 'Fable (7d)', color: 'fable' },
+    // seven_day_fable is deliberately absent — see PRIMARY_ROW_KEYS above.
     seven_day_cowork: { label: 'Cowork (7d)', color: 'cowork' },
     seven_day_omelette: { label: 'Design (7d)', color: 'design' },
     seven_day_oauth_apps: { label: 'OAuth Apps (7d)', color: 'oauth' },
@@ -862,7 +880,12 @@ function resizeWidget(bannerVisible) {
         ? EXPAND_OVERHEAD + (extraCount * WIDGET_ROW_HEIGHT)
         : 0;
     const graphOffset = graphVisible ? GRAPH_HEIGHT : 0;
-    const totalHeight = WIDGET_HEIGHT_COLLAPSED + expandedOffset + graphOffset + bannerOffset;
+    // WIDGET_HEIGHT_COLLAPSED covers the two always-present rows; the Fable
+    // row only exists on accounts that have the limit, so it is added rather
+    // than baked in. Mirrors getCompactHeight() in main.js, which already does
+    // this for compact mode.
+    const fableOffset = latestUsageData?.seven_day_fable ? FABLE_ROW_HEIGHT : 0;
+    const totalHeight = WIDGET_HEIGHT_COLLAPSED + fableOffset + expandedOffset + graphOffset + bannerOffset;
     window.electronAPI.resizeWindow(totalHeight);
 }
 
@@ -871,7 +894,7 @@ function normalizeUsageData(data) {
     // Fable) are produced centrally in main.js (normalize-usage-limits.js), so
     // `data` already carries them here. This renderer step only ensures every
     // scoped model has a matching EXTRA_ROW_CONFIG entry: statically known
-    // models (Fable) already do; any unknown model is registered generically
+    // models already do; any unknown model is registered generically
     // (label "<DisplayName> (7d)", fallback color) while keeping extra_usage as
     // the last row so it stays grouped below the model rows.
     for (const limit of (data && data.limits) || []) {
@@ -879,7 +902,10 @@ function normalizeUsageData(data) {
         const displayName = limit.scope && limit.scope.model && limit.scope.model.display_name;
         if (!displayName) continue;
         const key = 'seven_day_' + String(displayName).toLowerCase().replace(/[^a-z0-9]+/g, '_');
-        if (EXTRA_ROW_CONFIG[key]) continue; // already known (e.g. seven_day_fable)
+        // Fable has its own primary row; registering it here would add a
+        // duplicate generic row in the expansion.
+        if (PRIMARY_ROW_KEYS.has(key)) continue;
+        if (EXTRA_ROW_CONFIG[key]) continue; // already known
         const extraUsage = EXTRA_ROW_CONFIG.extra_usage;
         delete EXTRA_ROW_CONFIG.extra_usage;
         EXTRA_ROW_CONFIG[key] = { label: `${displayName} (7d)`, color: 'scoped' };
@@ -1263,6 +1289,30 @@ function refreshTimers() {
     );
     elements.weeklyResetsAt.textContent = formatResetsAt(weeklyResetsAt, true, timeFormat, weeklyDateFormat);
     elements.weeklyResetsAt.style.opacity = weeklyResetsAt ? '1' : '0.4';
+
+    // Fable — a weekly-scoped limit, so it reuses the weekly formatting and
+    // window length. Only accounts with the limit have data.seven_day_fable
+    // (normalized in main.js by src/normalize-usage-limits.js), so the row
+    // stays hidden otherwise and the window shrinks back accordingly.
+    const fable = latestUsageData.seven_day_fable;
+    elements.fableSection.style.display = fable ? '' : 'none';
+    if (fable) {
+        const fableResetsAt = fable.resets_at;
+        updateProgressBar(
+            elements.fableProgress,
+            elements.fablePercentage,
+            fable.utilization || 0,
+            true
+        );
+        updateTimer(
+            elements.fableTimer,
+            elements.fableTimeText,
+            fableResetsAt,
+            7 * 24 * 60 // 7 days in minutes
+        );
+        elements.fableResetsAt.textContent = formatResetsAt(fableResetsAt, true, timeFormat, weeklyDateFormat);
+        elements.fableResetsAt.style.opacity = fableResetsAt ? '1' : '0.4';
+    }
 }
 
 function startCountdown() {
@@ -1471,7 +1521,10 @@ function renderChart(history) {
 
     const showSonnet = isExpanded && !!latestUsageData?.seven_day_sonnet;
     const showOpus = isExpanded && !!latestUsageData?.seven_day_opus;
-    const showFable = isExpanded && !!latestUsageData?.seven_day_fable;
+    // Not gated on isExpanded, unlike the rows around it: Fable is a primary
+    // row now, always on screen, so its line belongs in the graph whenever the
+    // account has the limit — same rule as Session and Weekly below.
+    const showFable = !!latestUsageData?.seven_day_fable;
     const showCowork = isExpanded && !!latestUsageData?.seven_day_cowork;
     const showDesign = isExpanded && !!latestUsageData?.seven_day_omelette;
     const showOAuthApps = isExpanded && !!latestUsageData?.seven_day_oauth_apps;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -170,6 +170,29 @@
                     <div class="resets-at-text" id="weeklyResetsAt">--</div>
                 </div>
 
+                <!-- Fable Weekly — a primary row, not an expansion row, so it gets the
+                     same size and weight as Session and Weekly above. Hidden unless the
+                     account actually has a scoped Fable weekly limit; the compact-mode
+                     Fable row below follows the same hidden-by-default pattern. -->
+                <div class="usage-section" id="fableSection" style="display: none;">
+                    <span class="usage-label">Fable Weekly</span>
+                    <div class="usage-bar-group">
+                        <div class="progress-bar">
+                            <div class="progress-fill fable" id="fableProgress" style="width: 0%"></div>
+                        </div>
+                        <span class="usage-percentage" id="fablePercentage">0%</span>
+                    </div>
+                    <div class="usage-elapsed-group">
+                        <svg class="mini-timer" width="24" height="24" viewBox="0 0 24 24">
+                            <circle class="timer-bg" cx="12" cy="12" r="10" />
+                            <circle class="timer-progress fable" id="fableTimer" cx="12" cy="12" r="10"
+                                style="stroke-dasharray: 63; stroke-dashoffset: 63" />
+                        </svg>
+                    </div>
+                    <div class="timer-text" id="fableTimeText">--:--</div>
+                    <div class="resets-at-text" id="fableResetsAt">--</div>
+                </div>
+
                 <!-- Expand Toggle -->
                 <div class="expand-toggle" id="expandToggle">
                     <svg class="expand-arrow" id="expandArrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">


### PR DESCRIPTION
### What this does

Moves the Fable row out of the expansion and up alongside Session and Weekly.

Since #97 / the `feature/fable-usage` work landed, Fable renders inside the expand section. That section is deliberately de-emphasised — `.expand-section .usage-section` drops row height 32px → 28px and `.expand-section .usage-label` drops the label to 10px `#808080`, against 11px `#a0a0a0` for the primary rows — so Fable was both smaller and dimmer than its siblings, and invisible until you clicked the chevron. For anyone whose day-to-day model is Fable, that's the number they most want at a glance.

The row is now a third primary row directly under Weekly. The markup mirrors the Weekly block, so it picks up the primary styling with **no new CSS**: I compared computed styles and the label, percentage, timer and resets-at text match the Weekly row exactly on font-size, colour, weight, letter-spacing and text-transform. It's static markup hidden by default, the same pattern `compactFableRow` already uses for compact mode, since only accounts with a scoped Fable weekly limit have the data. Rendering reuses `updateProgressBar` / `updateTimer` / `formatResetsAt` with the weekly window length — no new rendering code.

Two things that weren't obvious:

**Keeping it out of the expansion needed more than deleting its `EXTRA_ROW_CONFIG` entry.** `normalizeUsageData()` re-registers any `weekly_scoped` limit missing from that config, so Fable came straight back as a generic grey "scoped" row and rendered twice. Added `PRIMARY_ROW_KEYS`, checked in that loop too, so the exclusion is stated once and holds in both places.

**The chart's `showFable` loses its `isExpanded` gate.** That gate exists because the other model series correspond to rows that only exist while expanded. Fable's row is now always on screen, so gating its line would leave the graph disagreeing with the rows in front of it — Session and Weekly are ungated for the same reason.

**Window height.** `WIDGET_HEIGHT_COLLAPSED` and `main.js`'s `WIDGET_HEIGHT` both assume two primary rows. Both now add the Fable row only when the account has the limit — the renderer in `resizeWidget()`, and the main process in a new `getNormalHeight()` placed beside `getCompactHeight()`, which already did exactly this for compact mode. `getNormalHeight()` also sizes the first paint, so accounts with Fable no longer see a resize a moment after launch.

`FABLE_ROW_HEIGHT` is 34 (32px row + 2px margin), measured rather than derived — `.usage-section:last-of-type` matches by tag name, not class, so it never applied to these rows and every row keeps its margin.

Only Fable is promoted. Opus, Sonnet, Design and OAuth Apps stay in the expansion; promoting all five would add roughly 160px to the default window and leave the expand toggle with almost nothing to show. Happy to change that if you'd rather it were configurable.

### Testing

Windows 11, against a live account that has a scoped Fable weekly limit.

- Renders `FABLE WEEKLY 12% 4d 20h Sun Aug 9 09:59` against Weekly's `WEEKLY LIMIT 14% …`, in Fable magenta
- Third of three primary rows, above the expand toggle
- Appears once — absent from the expansion, and `'seven_day_fable' in EXTRA_ROW_CONFIG` is `false` at runtime
- No clipping in any state: collapsed 189px window vs 185px content, expanded 247 vs 232, graph shown 421 vs 417
- Chart carries Session, Weekly and Fable while collapsed
- Compact mode untouched — its own Fable row still shows at a 148px window

### Notes

My PR for configurable colours builds on this one, since it needs a `#fableSection` to attach the Fable row's colours to. That PR's diff will shrink to just the colour work once this merges.
