### PR TITLE
feat: configurable row colours, and lighter/darker Elapsed-ring staging (discussion #100)

### DIFF
--- a/main.js
+++ b/main.js
@@ -394,14 +394,15 @@ const DEFAULT_STATUS_COLORS = {
   weeklyRingColor: '#3b82f6',
   fableBarColor: '#d946ef',
   fableRingColor: '#d946ef',
-  spendBarColor: '#10b981'
+  spendBarColor: '#bc1010'
 };
 
 // Elapsed-ring staging mode and the two distances it travels. Pass-through
-// state for the main process; the renderer does the derivation.
-const DEFAULT_ELAPSED_MODE = 'custom';
-const DEFAULT_ELAPSED_WARN_PERCENT = 66;
-const DEFAULT_ELAPSED_SOON_PERCENT = 80;
+// state for the main process; the renderer does the derivation. See the
+// matching block in src/renderer/app.js for why 'lighter' is the default.
+const DEFAULT_ELAPSED_MODE = 'lighter';
+const DEFAULT_ELAPSED_WARN_PERCENT = 20;
+const DEFAULT_ELAPSED_SOON_PERCENT = 40;
 
 /**
  * Parse a #rrggbb string into the {r,g,b} the icon bitmaps need.

--- a/main.js
+++ b/main.js
@@ -373,15 +373,41 @@ function createMainWindow() {
 }
 
 /**
- * Determine background color based on thresholds
+ * Default status colors. Must stay in step with DEFAULT_STATUS_COLORS in
+ * src/renderer/app.js and the :root block in src/renderer/styles.css.
+ * All four are stored and handed to the renderer, but only the two usage
+ * colors are drawn here — the tray renders usage badges, never elapsed-time
+ * rings, so the elapsed pair is pass-through state for the main process.
  */
-function getBackgroundColor(percent, isSession, warnThreshold, dangerThreshold) {
+const DEFAULT_STATUS_COLORS = {
+  warnColor: '#f59e0b',
+  dangerColor: '#ef4444',
+  elapsedWarnColor: '#f59e0b',
+  elapsedSoonColor: '#10b981'
+};
+
+/**
+ * Parse a #rrggbb string into the {r,g,b} the icon bitmaps need.
+ * Returns null on anything unparseable so callers can fall back.
+ */
+function hexToRgb(hex) {
+  const m = /^#?([0-9a-f]{6})$/i.exec(String(hex).trim());
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+/**
+ * Determine background color based on thresholds.
+ * The warn/danger colors are user-configurable (Settings > Warn at); the
+ * session-purple and weekly-blue below are identity colors that say *which*
+ * badge this is, not how full it is, so they stay fixed.
+ */
+function getBackgroundColor(percent, isSession, warnThreshold, dangerThreshold, warnColor, dangerColor) {
   if (percent >= dangerThreshold) {
-    // Red #ef4444
-    return { r: 239, g: 68, b: 68 };
+    return hexToRgb(dangerColor) || hexToRgb(DEFAULT_STATUS_COLORS.dangerColor);
   } else if (percent >= warnThreshold) {
-    // Amber/Orange #f59e0b
-    return { r: 245, g: 158, b: 11 };
+    return hexToRgb(warnColor) || hexToRgb(DEFAULT_STATUS_COLORS.warnColor);
   } else {
     // Default colors
     if (isSession) {
@@ -897,6 +923,8 @@ function updateTrayIcon(usageData) {
   // Get threshold settings and time format
   const warnThreshold = store.get('settings.warnThreshold', 75);
   const dangerThreshold = store.get('settings.dangerThreshold', 90);
+  const warnColor = store.get('settings.warnColor', DEFAULT_STATUS_COLORS.warnColor);
+  const dangerColor = store.get('settings.dangerColor', DEFAULT_STATUS_COLORS.dangerColor);
   const timeFormat = store.get('settings.timeFormat', '12h');
 
   // Extract percentages and reset times from usage data
@@ -911,7 +939,7 @@ function updateTrayIcon(usageData) {
     if (weeklyPercent >= 99) {
       weeklyIcon = generateRedXIcon();
     } else {
-      const weeklyColor = getBackgroundColor(weeklyPercent, false, warnThreshold, dangerThreshold);
+      const weeklyColor = getBackgroundColor(weeklyPercent, false, warnThreshold, dangerThreshold, warnColor, dangerColor);
       weeklyIcon = generatePercentageIcon(weeklyPercent, weeklyColor);
     }
     if (weeklyTray && !weeklyTray.isDestroyed()) {
@@ -929,7 +957,7 @@ function updateTrayIcon(usageData) {
     if (sessionPercent >= 99) {
       sessionIcon = generateRedXIcon();
     } else {
-      const sessionColor = getBackgroundColor(sessionPercent, true, warnThreshold, dangerThreshold);
+      const sessionColor = getBackgroundColor(sessionPercent, true, warnThreshold, dangerThreshold, warnColor, dangerColor);
       sessionIcon = generatePercentageIcon(sessionPercent, sessionColor);
     }
     if (sessionTray && !sessionTray.isDestroyed()) {
@@ -1162,6 +1190,10 @@ ipcMain.handle('get-settings', () => {
     theme: store.get('settings.theme', 'dark'),
     warnThreshold: store.get('settings.warnThreshold', 75),
     dangerThreshold: store.get('settings.dangerThreshold', 90),
+    warnColor: store.get('settings.warnColor', DEFAULT_STATUS_COLORS.warnColor),
+    dangerColor: store.get('settings.dangerColor', DEFAULT_STATUS_COLORS.dangerColor),
+    elapsedWarnColor: store.get('settings.elapsedWarnColor', DEFAULT_STATUS_COLORS.elapsedWarnColor),
+    elapsedSoonColor: store.get('settings.elapsedSoonColor', DEFAULT_STATUS_COLORS.elapsedSoonColor),
     timeFormat: store.get('settings.timeFormat', '12h'),
     weeklyDateFormat: store.get('settings.weeklyDateFormat', 'date'),
     usageAlerts: store.get('settings.usageAlerts', true),
@@ -1184,6 +1216,12 @@ ipcMain.handle('save-settings', (event, settings) => {
   store.set('settings.theme', settings.theme);
   store.set('settings.warnThreshold', settings.warnThreshold);
   store.set('settings.dangerThreshold', settings.dangerThreshold);
+  // Guarded like compactSpendOpen below: several call sites persist a settings
+  // object that predates these fields, and an unguarded set would blank the
+  // stored colors on the next view-state save.
+  for (const key of Object.keys(DEFAULT_STATUS_COLORS)) {
+    if (settings[key] !== undefined) store.set(`settings.${key}`, settings[key]);
+  }
   store.set('settings.timeFormat', settings.timeFormat);
   store.set('settings.weeklyDateFormat', settings.weeklyDateFormat);
   store.set('settings.usageAlerts', settings.usageAlerts);

--- a/main.js
+++ b/main.js
@@ -101,6 +101,7 @@ const COMPACT_HEIGHT = 105;
 const COMPACT_ROW_HEIGHT = 28; // extra height per optional row (Fable, Spend)
 const COMPACT_CHEVRON_HEIGHT = 15; // the always-visible spend toggle chevron
 const COMPACT_BANNER_HEIGHT = 28; // matches BANNER_HEIGHT in the renderer's resizeWidget()
+const FABLE_ROW_HEIGHT = 34; // matches FABLE_ROW_HEIGHT in the renderer's app.js
 const HISTORY_RETENTION_DAYS = 8;
 
 // Compact mode always shows Session + Weekly plus the spend chevron; grows by
@@ -117,6 +118,20 @@ function getCompactHeight() {
   if (store.get('settings.compactSpendOpen', false)) height += COMPACT_ROW_HEIGHT;
   if (store.get('updateBannerVisible', false)) height += COMPACT_BANNER_HEIGHT;
   return height;
+}
+
+// Normal mode's collapsed height. WIDGET_HEIGHT covers Session + Weekly; the
+// Fable primary row only exists on accounts that have that scoped weekly
+// limit, so it is added the same way getCompactHeight() adds its own Fable
+// row. Kept beside it so the two can't drift apart.
+//
+// The renderer recomputes the full height itself in resizeWidget() (which also
+// accounts for the expansion, graph and update banner). This is the main
+// process's answer for the two moments it sizes the window without asking:
+// first paint, and returning from compact mode.
+function getNormalHeight() {
+  const data = store.get('latestUsageData');
+  return WIDGET_HEIGHT + (data?.seven_day_fable ? FABLE_ROW_HEIGHT : 0);
 }
 const CHART_DAYS = 7;
 const MAX_HISTORY_SAMPLES = 10000; // Cap total samples to prevent unbounded growth
@@ -277,14 +292,17 @@ function showMainWindowSmart() {
 }
 
 function createMainWindow() {
+  // Size the first paint for the Fable row too, so accounts that have the
+  // limit don't get a visible resize a moment after launch.
+  const startHeight = getNormalHeight();
   let savedPosition = store.get('windowPosition');
-  if (savedPosition && !isPositionOnScreen(savedPosition.x, savedPosition.y, WIDGET_WIDTH, WIDGET_HEIGHT)) {
+  if (savedPosition && !isPositionOnScreen(savedPosition.x, savedPosition.y, WIDGET_WIDTH, startHeight)) {
     debugLog('[Window] Saved position', savedPosition, 'is off-screen on current display setup; centering instead');
     savedPosition = null;
   }
   const windowOptions = {
     width: WIDGET_WIDTH,
-    height: WIDGET_HEIGHT,
+    height: startHeight,
     frame: false,
     transparent: true,
     alwaysOnTop: true,
@@ -1130,7 +1148,7 @@ ipcMain.on('set-compact-mode', (event, compact) => {
   if (mainWindow) {
     const bounds = mainWindow.getBounds();
     const width = compact ? COMPACT_WIDTH : WIDGET_WIDTH;
-    const height = compact ? getCompactHeight() : WIDGET_HEIGHT;
+    const height = compact ? getCompactHeight() : getNormalHeight();
     mainWindow.setBounds({ x: bounds.x, y: bounds.y, width, height });
   }
 });

--- a/main.js
+++ b/main.js
@@ -373,18 +373,35 @@ function createMainWindow() {
 }
 
 /**
- * Default status colors. Must stay in step with DEFAULT_STATUS_COLORS in
- * src/renderer/app.js and the :root block in src/renderer/styles.css.
- * All four are stored and handed to the renderer, but only the two usage
- * colors are drawn here — the tray renders usage badges, never elapsed-time
- * rings, so the elapsed pair is pass-through state for the main process.
+ * Default colors. Must stay in step with DEFAULT_STATUS_COLORS and
+ * DEFAULT_ROW_COLORS in src/renderer/app.js and the :root block in
+ * src/renderer/styles.css.
+ * All are stored and handed to the renderer, but only warnColor, dangerColor
+ * and the two bar colors are drawn here — the tray renders usage badges, never
+ * elapsed-time rings — so the rest is pass-through state for this process.
  */
 const DEFAULT_STATUS_COLORS = {
   warnColor: '#f59e0b',
   dangerColor: '#ef4444',
   elapsedWarnColor: '#f59e0b',
-  elapsedSoonColor: '#10b981'
+  elapsedSoonColor: '#10b981',
+  // Row identity colors. Only the two bar colors below are drawn in this
+  // process (the tray badges); the rest are stored here purely so the renderer
+  // gets them back through get-settings.
+  sessionBarColor: '#8b5cf6',
+  sessionRingColor: '#8b5cf6',
+  weeklyBarColor: '#3b82f6',
+  weeklyRingColor: '#3b82f6',
+  fableBarColor: '#d946ef',
+  fableRingColor: '#d946ef',
+  spendBarColor: '#10b981'
 };
+
+// Elapsed-ring staging mode and the two distances it travels. Pass-through
+// state for the main process; the renderer does the derivation.
+const DEFAULT_ELAPSED_MODE = 'custom';
+const DEFAULT_ELAPSED_WARN_PERCENT = 66;
+const DEFAULT_ELAPSED_SOON_PERCENT = 80;
 
 /**
  * Parse a #rrggbb string into the {r,g,b} the icon bitmaps need.
@@ -398,25 +415,20 @@ function hexToRgb(hex) {
 }
 
 /**
- * Determine background color based on thresholds.
- * The warn/danger colors are user-configurable (Settings > Warn at); the
- * session-purple and weekly-blue below are identity colors that say *which*
- * badge this is, not how full it is, so they stay fixed.
+ * Determine badge background color. Above a threshold the badge takes the
+ * warn/danger color; below it, the row's own identity color — so a glance at
+ * the tray tells you which badge you are looking at and how full it is. All
+ * four are user-configurable on the Colours page.
  */
-function getBackgroundColor(percent, isSession, warnThreshold, dangerThreshold, warnColor, dangerColor) {
+function getBackgroundColor(percent, isSession, warnThreshold, dangerThreshold, colors = {}) {
   if (percent >= dangerThreshold) {
-    return hexToRgb(dangerColor) || hexToRgb(DEFAULT_STATUS_COLORS.dangerColor);
+    return hexToRgb(colors.dangerColor) || hexToRgb(DEFAULT_STATUS_COLORS.dangerColor);
   } else if (percent >= warnThreshold) {
-    return hexToRgb(warnColor) || hexToRgb(DEFAULT_STATUS_COLORS.warnColor);
+    return hexToRgb(colors.warnColor) || hexToRgb(DEFAULT_STATUS_COLORS.warnColor);
+  } else if (isSession) {
+    return hexToRgb(colors.sessionBarColor) || hexToRgb(DEFAULT_STATUS_COLORS.sessionBarColor);
   } else {
-    // Default colors
-    if (isSession) {
-      // Purple #8b5cf6
-      return { r: 139, g: 92, b: 246 };
-    } else {
-      // Blue #3b82f6
-      return { r: 59, g: 130, b: 246 };
-    }
+    return hexToRgb(colors.weeklyBarColor) || hexToRgb(DEFAULT_STATUS_COLORS.weeklyBarColor);
   }
 }
 
@@ -923,8 +935,12 @@ function updateTrayIcon(usageData) {
   // Get threshold settings and time format
   const warnThreshold = store.get('settings.warnThreshold', 75);
   const dangerThreshold = store.get('settings.dangerThreshold', 90);
-  const warnColor = store.get('settings.warnColor', DEFAULT_STATUS_COLORS.warnColor);
-  const dangerColor = store.get('settings.dangerColor', DEFAULT_STATUS_COLORS.dangerColor);
+  const badgeColors = {
+    warnColor: store.get('settings.warnColor', DEFAULT_STATUS_COLORS.warnColor),
+    dangerColor: store.get('settings.dangerColor', DEFAULT_STATUS_COLORS.dangerColor),
+    sessionBarColor: store.get('settings.sessionBarColor', DEFAULT_STATUS_COLORS.sessionBarColor),
+    weeklyBarColor: store.get('settings.weeklyBarColor', DEFAULT_STATUS_COLORS.weeklyBarColor)
+  };
   const timeFormat = store.get('settings.timeFormat', '12h');
 
   // Extract percentages and reset times from usage data
@@ -939,7 +955,7 @@ function updateTrayIcon(usageData) {
     if (weeklyPercent >= 99) {
       weeklyIcon = generateRedXIcon();
     } else {
-      const weeklyColor = getBackgroundColor(weeklyPercent, false, warnThreshold, dangerThreshold, warnColor, dangerColor);
+      const weeklyColor = getBackgroundColor(weeklyPercent, false, warnThreshold, dangerThreshold, badgeColors);
       weeklyIcon = generatePercentageIcon(weeklyPercent, weeklyColor);
     }
     if (weeklyTray && !weeklyTray.isDestroyed()) {
@@ -957,7 +973,7 @@ function updateTrayIcon(usageData) {
     if (sessionPercent >= 99) {
       sessionIcon = generateRedXIcon();
     } else {
-      const sessionColor = getBackgroundColor(sessionPercent, true, warnThreshold, dangerThreshold, warnColor, dangerColor);
+      const sessionColor = getBackgroundColor(sessionPercent, true, warnThreshold, dangerThreshold, badgeColors);
       sessionIcon = generatePercentageIcon(sessionPercent, sessionColor);
     }
     if (sessionTray && !sessionTray.isDestroyed()) {
@@ -1190,10 +1206,11 @@ ipcMain.handle('get-settings', () => {
     theme: store.get('settings.theme', 'dark'),
     warnThreshold: store.get('settings.warnThreshold', 75),
     dangerThreshold: store.get('settings.dangerThreshold', 90),
-    warnColor: store.get('settings.warnColor', DEFAULT_STATUS_COLORS.warnColor),
-    dangerColor: store.get('settings.dangerColor', DEFAULT_STATUS_COLORS.dangerColor),
-    elapsedWarnColor: store.get('settings.elapsedWarnColor', DEFAULT_STATUS_COLORS.elapsedWarnColor),
-    elapsedSoonColor: store.get('settings.elapsedSoonColor', DEFAULT_STATUS_COLORS.elapsedSoonColor),
+    ...Object.fromEntries(Object.entries(DEFAULT_STATUS_COLORS)
+      .map(([key, fallback]) => [key, store.get(`settings.${key}`, fallback)])),
+    elapsedColorMode: store.get('settings.elapsedColorMode', DEFAULT_ELAPSED_MODE),
+    elapsedWarnPercent: store.get('settings.elapsedWarnPercent', DEFAULT_ELAPSED_WARN_PERCENT),
+    elapsedSoonPercent: store.get('settings.elapsedSoonPercent', DEFAULT_ELAPSED_SOON_PERCENT),
     timeFormat: store.get('settings.timeFormat', '12h'),
     weeklyDateFormat: store.get('settings.weeklyDateFormat', 'date'),
     usageAlerts: store.get('settings.usageAlerts', true),
@@ -1218,8 +1235,12 @@ ipcMain.handle('save-settings', (event, settings) => {
   store.set('settings.dangerThreshold', settings.dangerThreshold);
   // Guarded like compactSpendOpen below: several call sites persist a settings
   // object that predates these fields, and an unguarded set would blank the
-  // stored colors on the next view-state save.
-  for (const key of Object.keys(DEFAULT_STATUS_COLORS)) {
+  // stored values on the next view-state save.
+  const colorKeys = [
+    ...Object.keys(DEFAULT_STATUS_COLORS),
+    'elapsedColorMode', 'elapsedWarnPercent', 'elapsedSoonPercent'
+  ];
+  for (const key of colorKeys) {
     if (settings[key] !== undefined) store.set(`settings.${key}`, settings[key]);
   }
   store.set('settings.timeFormat', settings.timeFormat);

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -15,6 +15,10 @@ let isFetching = false;       // in-flight guard — prevents overlapping fetchU
 const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const WIDGET_HEIGHT_COLLAPSED = 155;
 const WIDGET_ROW_HEIGHT = 30;
+// Height the optional Fable primary row adds: .usage-section is 32px tall with
+// a 2px bottom margin. Must match FABLE_ROW_HEIGHT in main.js, which sizes the
+// same window from the main process.
+const FABLE_ROW_HEIGHT = 34;
 const GRAPH_HEIGHT = 232;
 
 // Elapsed-time ring thresholds (session/weekly/extra-row countdown circles).
@@ -65,6 +69,13 @@ const elements = {
     weeklyTimer: document.getElementById('weeklyTimer'),
     weeklyTimeText: document.getElementById('weeklyTimeText'),
     weeklyResetsAt: document.getElementById('weeklyResetsAt'),
+
+    fableSection: document.getElementById('fableSection'),
+    fablePercentage: document.getElementById('fablePercentage'),
+    fableProgress: document.getElementById('fableProgress'),
+    fableTimer: document.getElementById('fableTimer'),
+    fableTimeText: document.getElementById('fableTimeText'),
+    fableResetsAt: document.getElementById('fableResetsAt'),
 
     sessionResetsAt: document.getElementById('sessionResetsAt'),
 
@@ -588,11 +599,18 @@ function formatCurrency(amountCents, currencyCode) {
   return sym ? `${sym}${amount}` : `${amount} ${currencyCode || 'USD'}`;
 }
 
+// Usage keys that have their own always-visible row in the main widget body
+// rather than a row inside the expansion. These must be excluded from BOTH
+// EXTRA_ROW_CONFIG below and the scoped-model registration in
+// normalizeUsageData(), or the same limit renders twice — once as a primary
+// row and once as a generic "scoped" row in the expansion.
+const PRIMARY_ROW_KEYS = new Set(['seven_day_fable']);
+
 // Extra row label mapping for API fields
 const EXTRA_ROW_CONFIG = {
     seven_day_sonnet: { label: 'Sonnet (7d)', color: 'sonnet' },
     seven_day_opus: { label: 'Opus (7d)', color: 'opus' },
-    seven_day_fable: { label: 'Fable (7d)', color: 'fable' },
+    // seven_day_fable is deliberately absent — see PRIMARY_ROW_KEYS above.
     seven_day_cowork: { label: 'Cowork (7d)', color: 'cowork' },
     seven_day_omelette: { label: 'Design (7d)', color: 'design' },
     seven_day_oauth_apps: { label: 'OAuth Apps (7d)', color: 'oauth' },
@@ -862,7 +880,12 @@ function resizeWidget(bannerVisible) {
         ? EXPAND_OVERHEAD + (extraCount * WIDGET_ROW_HEIGHT)
         : 0;
     const graphOffset = graphVisible ? GRAPH_HEIGHT : 0;
-    const totalHeight = WIDGET_HEIGHT_COLLAPSED + expandedOffset + graphOffset + bannerOffset;
+    // WIDGET_HEIGHT_COLLAPSED covers the two always-present rows; the Fable
+    // row only exists on accounts that have the limit, so it is added rather
+    // than baked in. Mirrors getCompactHeight() in main.js, which already does
+    // this for compact mode.
+    const fableOffset = latestUsageData?.seven_day_fable ? FABLE_ROW_HEIGHT : 0;
+    const totalHeight = WIDGET_HEIGHT_COLLAPSED + fableOffset + expandedOffset + graphOffset + bannerOffset;
     window.electronAPI.resizeWindow(totalHeight);
 }
 
@@ -871,7 +894,7 @@ function normalizeUsageData(data) {
     // Fable) are produced centrally in main.js (normalize-usage-limits.js), so
     // `data` already carries them here. This renderer step only ensures every
     // scoped model has a matching EXTRA_ROW_CONFIG entry: statically known
-    // models (Fable) already do; any unknown model is registered generically
+    // models already do; any unknown model is registered generically
     // (label "<DisplayName> (7d)", fallback color) while keeping extra_usage as
     // the last row so it stays grouped below the model rows.
     for (const limit of (data && data.limits) || []) {
@@ -879,7 +902,10 @@ function normalizeUsageData(data) {
         const displayName = limit.scope && limit.scope.model && limit.scope.model.display_name;
         if (!displayName) continue;
         const key = 'seven_day_' + String(displayName).toLowerCase().replace(/[^a-z0-9]+/g, '_');
-        if (EXTRA_ROW_CONFIG[key]) continue; // already known (e.g. seven_day_fable)
+        // Fable has its own primary row; registering it here would add a
+        // duplicate generic row in the expansion.
+        if (PRIMARY_ROW_KEYS.has(key)) continue;
+        if (EXTRA_ROW_CONFIG[key]) continue; // already known
         const extraUsage = EXTRA_ROW_CONFIG.extra_usage;
         delete EXTRA_ROW_CONFIG.extra_usage;
         EXTRA_ROW_CONFIG[key] = { label: `${displayName} (7d)`, color: 'scoped' };
@@ -1263,6 +1289,30 @@ function refreshTimers() {
     );
     elements.weeklyResetsAt.textContent = formatResetsAt(weeklyResetsAt, true, timeFormat, weeklyDateFormat);
     elements.weeklyResetsAt.style.opacity = weeklyResetsAt ? '1' : '0.4';
+
+    // Fable — a weekly-scoped limit, so it reuses the weekly formatting and
+    // window length. Only accounts with the limit have data.seven_day_fable
+    // (normalized in main.js by src/normalize-usage-limits.js), so the row
+    // stays hidden otherwise and the window shrinks back accordingly.
+    const fable = latestUsageData.seven_day_fable;
+    elements.fableSection.style.display = fable ? '' : 'none';
+    if (fable) {
+        const fableResetsAt = fable.resets_at;
+        updateProgressBar(
+            elements.fableProgress,
+            elements.fablePercentage,
+            fable.utilization || 0,
+            true
+        );
+        updateTimer(
+            elements.fableTimer,
+            elements.fableTimeText,
+            fableResetsAt,
+            7 * 24 * 60 // 7 days in minutes
+        );
+        elements.fableResetsAt.textContent = formatResetsAt(fableResetsAt, true, timeFormat, weeklyDateFormat);
+        elements.fableResetsAt.style.opacity = fableResetsAt ? '1' : '0.4';
+    }
 }
 
 function startCountdown() {
@@ -1471,7 +1521,10 @@ function renderChart(history) {
 
     const showSonnet = isExpanded && !!latestUsageData?.seven_day_sonnet;
     const showOpus = isExpanded && !!latestUsageData?.seven_day_opus;
-    const showFable = isExpanded && !!latestUsageData?.seven_day_fable;
+    // Not gated on isExpanded, unlike the rows around it: Fable is a primary
+    // row now, always on screen, so its line belongs in the graph whenever the
+    // account has the limit — same rule as Session and Weekly below.
+    const showFable = !!latestUsageData?.seven_day_fable;
     const showCowork = isExpanded && !!latestUsageData?.seven_day_cowork;
     const showDesign = isExpanded && !!latestUsageData?.seven_day_omelette;
     const showOAuthApps = isExpanded && !!latestUsageData?.seven_day_oauth_apps;

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -67,7 +67,9 @@ const DEFAULT_ROW_COLORS = {
     weeklyRingColor: '#3b82f6',
     fableBarColor: '#d946ef',
     fableRingColor: '#d946ef',
-    spendBarColor: '#10b981'
+    // Red, not the green it used to be: Monthly Spend is money leaving, which
+    // is the one row where a rising bar is unambiguously bad news.
+    spendBarColor: '#bc1010'
 };
 
 // Every configurable color in one place, for the settings round-trip and the
@@ -76,17 +78,23 @@ const DEFAULT_COLORS = { ...DEFAULT_STATUS_COLORS, ...DEFAULT_ROW_COLORS };
 
 // How the elapsed rings pick their 75%/90% colors.
 //   custom  — the two elapsedWarnColor/elapsedSoonColor pickers, one pair for
-//             every ring (what the app did before this existed)
+//             every ring
 //   lighter — each ring stages through lighter shades of ITS OWN color
 //   darker  — the same, toward black
-// Default is 'custom', so upgrading changes nothing until it's switched.
+//
+// Defaults to 'lighter'. A window approaching its reset is good news — your
+// limit is about to refresh — so staging it through amber and red framed a
+// routine, welcome event as an alarm. Lightening keeps the row's own hue, so
+// the ring still says which row it belongs to while brightening as the reset
+// nears. The old amber/red pair is still one radio button away under 'custom'.
 const ELAPSED_COLOR_MODES = ['custom', 'lighter', 'darker'];
-const DEFAULT_ELAPSED_MODE = 'custom';
+const DEFAULT_ELAPSED_MODE = 'lighter';
 
 // How far to travel toward white/black, as a percentage of the distance
 // remaining, for each of the two stages. Configurable on the Colours page.
-const DEFAULT_ELAPSED_WARN_PERCENT = 66;
-const DEFAULT_ELAPSED_SOON_PERCENT = 80;
+// Kept subtle on purpose: enough to read at a glance, not enough to shout.
+const DEFAULT_ELAPSED_WARN_PERCENT = 20;
+const DEFAULT_ELAPSED_SOON_PERCENT = 40;
 
 // Ring base colors for the rows that aren't individually configurable. The
 // three that are (session/weekly/fable) come from settings instead. Keyed by
@@ -140,7 +148,9 @@ const DEFAULT_LIGHT_STOPS = {
     '#8b5cf6': '#a78bfa', // Current Session
     '#3b82f6': '#60a5fa', // Weekly Limit
     '#d946ef': '#e879f9', // Fable Weekly
-    '#10b981': '#34d399'  // Monthly Spend
+    '#10b981': '#34d399'  // the old Monthly Spend green, and the custom-mode
+                          // elapsed-soon default; kept so picking it still
+                          // gets the hand-tuned partner
 };
 
 function lightStopFor(hex) {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -37,12 +37,14 @@ const ELAPSED_GREEN_THRESHOLD = 90;
 // 343 keeps the same slack around the block that six rows had.
 const SETTINGS_HEIGHT = 343;
 
-// Height of the Colours page window. Measured against the running panel, like
-// SETTINGS_HEIGHT above — .colours-rows has no scrollbar, and because it is a
-// flex:1 child it silently grows past the window rather than reporting an
-// overflow, so an undersized value clips the bottom row with no other symptom.
-// 423 = 36px header + 375px of rows + 12px breathing room, measured.
-const COLOURS_HEIGHT = 423;
+// Height of the Colours page window. Measured in the running app, like
+// SETTINGS_HEIGHT above: 36px header + 261px of rows + 24px breathing room.
+//
+// .colours-rows has no scrollbar, and because it is a flex:1 child it grows
+// past the window rather than reporting an overflow — scrollHeight and
+// clientHeight agree even when the bottom row sits below the window edge. The
+// check that actually works is the last row's bottom against innerHeight.
+const COLOURS_HEIGHT = 321;
 
 // Default colors. Must stay in step with the :root block in styles.css and
 // with the same defaults in main.js's get-settings/save-settings handlers.

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -31,11 +31,132 @@ const GRAPH_HEIGHT = 232;
 const ELAPSED_AMBER_THRESHOLD = 75;
 const ELAPSED_GREEN_THRESHOLD = 90;
 
+// Settings-panel window height. .settings-rows is a centred flex column with
+// no scrollbar, so this has to cover the rows outright. Was 318 for six rows;
+// the elapsed-ring color row costs 25px (a 15px row plus the 10px gap), and
+// 343 keeps the same slack around the block that six rows had.
+const SETTINGS_HEIGHT = 343;
+
+// Default status colors. Must stay in step with the :root block in styles.css
+// and with the same defaults in main.js's get-settings/save-settings handlers.
+const DEFAULT_STATUS_COLORS = {
+    warnColor: '#f59e0b',
+    dangerColor: '#ef4444',
+    elapsedWarnColor: '#f59e0b',
+    elapsedSoonColor: '#10b981'
+};
+
 // Debug logging — only shows in DevTools (development mode).
 // Regular users won't see verbose logs in production.
 const DEBUG = (new URLSearchParams(window.location.search)).has('debug');
 function debugLog(...args) {
   if (DEBUG) console.log('[Debug]', ...args);
+}
+
+// --- Status color helpers -------------------------------------------------
+// The usage bars are gradients (base -> lighter) with a glow shadow tinted to
+// match. Asking for three values per state would be tedious, so the user picks
+// the base and the other two are resolved here — which also keeps all three in
+// agreement whatever gets picked. The elapsed rings are a flat stroke and need
+// only their base color.
+
+function hexToRgb(hex) {
+    const m = /^#?([0-9a-f]{6})$/i.exec(String(hex).trim());
+    if (!m) return null;
+    const n = parseInt(m[1], 16);
+    return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function hexToRgba(hex, alpha) {
+    const rgb = hexToRgb(hex);
+    if (!rgb) return `rgba(0, 0, 0, ${alpha})`;
+    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+}
+
+// The gradient partners this app has always used. They are hand-picked
+// Tailwind steps (amber-500 -> amber-400, red-500 -> red-400) that shift hue
+// and saturation as well as lightness, so no single lighten formula
+// reproduces them. Kept as data rather than approximated, so an install that
+// never touches the pickers renders exactly as it always has; anything the
+// user picks falls through to lightenHex().
+const DEFAULT_LIGHT_STOPS = {
+    '#f59e0b': '#fbbf24',
+    '#ef4444': '#f87171'
+};
+
+function lightStopFor(hex) {
+    return DEFAULT_LIGHT_STOPS[String(hex).toLowerCase()] || lightenHex(hex);
+}
+
+// Lighten by raising HSL lightness, with a small saturation bump. Lightness
+// alone washes mid-tones out — the bump keeps the lighter stop reading as the
+// same color rather than a faded one, which is the direction the hand-picked
+// pairs above go in too.
+function lightenHex(hex, lightBy = 12, satBy = 5) {
+    const rgb = hexToRgb(hex);
+    if (!rgb) return hex;
+    const r = rgb.r / 255, g = rgb.g / 255, b = rgb.b / 255;
+    const max = Math.max(r, g, b), min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    let h = 0, s = 0;
+    if (max !== min) {
+        const d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+        else if (max === g) h = ((b - r) / d + 2) / 6;
+        else h = ((r - g) / d + 4) / 6;
+    }
+    const l2 = Math.min(1, Math.max(0, l + lightBy / 100));
+    // Only bump saturation on colors that have some — adding it to a grey
+    // (s === 0, where hue is meaningless and defaults to 0) would tint it red.
+    const s2 = s === 0 ? 0 : Math.min(1, Math.max(0, s + satBy / 100));
+
+    const hueToRgb = (p, q, t) => {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1 / 6) return p + (q - p) * 6 * t;
+        if (t < 1 / 2) return q;
+        if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+        return p;
+    };
+    const q = l2 < 0.5 ? l2 * (1 + s2) : l2 + s2 - l2 * s2;
+    const p = 2 * l2 - q;
+    const toHex = (v) => Math.round(v * 255).toString(16).padStart(2, '0');
+    return `#${toHex(hueToRgb(p, q, h + 1 / 3))}${toHex(hueToRgb(p, q, h))}${toHex(hueToRgb(p, q, h - 1 / 3))}`;
+}
+
+// Push the chosen colors into the CSS custom properties that styles.css reads.
+// Everything colored by threshold state — expanded bars, compact bars and the
+// elapsed rings — follows from these, so there is one write per state rather
+// than a sweep over elements.
+function applyStatusColors(settings = {}) {
+    const colors = { ...DEFAULT_STATUS_COLORS };
+    for (const key of Object.keys(DEFAULT_STATUS_COLORS)) {
+        if (hexToRgb(settings[key])) colors[key] = settings[key];
+    }
+
+    const root = document.documentElement;
+    root.style.setProperty('--status-warn', colors.warnColor);
+    root.style.setProperty('--status-warn-light', lightStopFor(colors.warnColor));
+    root.style.setProperty('--status-warn-glow', hexToRgba(colors.warnColor, 0.3));
+    root.style.setProperty('--status-danger', colors.dangerColor);
+    root.style.setProperty('--status-danger-light', lightStopFor(colors.dangerColor));
+    root.style.setProperty('--status-danger-glow', hexToRgba(colors.dangerColor, 0.3));
+    root.style.setProperty('--elapsed-warn', colors.elapsedWarnColor);
+    root.style.setProperty('--elapsed-soon', colors.elapsedSoonColor);
+
+    return colors;
+}
+
+// Current picker values, falling back to the defaults for any input that is
+// missing (older cached markup) or holding something unparseable.
+function readColorInputs() {
+    const colors = {};
+    for (const key of Object.keys(DEFAULT_STATUS_COLORS)) {
+        const value = elements[key] ? elements[key].value : null;
+        colors[key] = hexToRgb(value) ? value.toLowerCase() : DEFAULT_STATUS_COLORS[key];
+    }
+    return colors;
 }
 
 // DOM elements
@@ -99,6 +220,11 @@ const elements = {
     showTrayStatsToggle: document.getElementById('showTrayStatsToggle'),
     warnThreshold: document.getElementById('warnThreshold'),
     dangerThreshold: document.getElementById('dangerThreshold'),
+    warnColor: document.getElementById('warnColor'),
+    dangerColor: document.getElementById('dangerColor'),
+    elapsedWarnColor: document.getElementById('elapsedWarnColor'),
+    elapsedSoonColor: document.getElementById('elapsedSoonColor'),
+    resetColorsLink: document.getElementById('resetColorsLink'),
     themeBtns: document.querySelectorAll('.theme-btn'),
     timeFormat: document.getElementById('timeFormat'),
     weeklyDateFormat: document.getElementById('weeklyDateFormat'),
@@ -184,6 +310,8 @@ async function init() {
     const settings = await window.electronAPI.getSettings();
     window._cachedSettings = settings;
     applyTheme(settings.theme);
+    // Before the first render, so bars/rings never flash the defaults first.
+    applyStatusColors(settings);
     if (window.electronAPI.platform === 'darwin') {
         document.getElementById('trayLabel').textContent = 'Hide from Dock';
     }
@@ -366,6 +494,24 @@ function setupEventListeners() {
         });
     });
 
+    // Color pickers — repaint live while the OS picker is open so the choice
+    // can be judged against real bars. Like the theme buttons and the
+    // threshold numbers, nothing is persisted until Done (saveSettings).
+    // Tray badges are drawn in the main process and so only follow on Done.
+    for (const key of Object.keys(DEFAULT_STATUS_COLORS)) {
+        if (!elements[key]) continue;
+        elements[key].addEventListener('input', () => applyStatusColors(readColorInputs()));
+    }
+
+    if (elements.resetColorsLink) {
+        elements.resetColorsLink.addEventListener('click', () => {
+            for (const [key, value] of Object.entries(DEFAULT_STATUS_COLORS)) {
+                if (elements[key]) elements[key].value = value;
+            }
+            applyStatusColors(DEFAULT_STATUS_COLORS);
+        });
+    }
+
     // Prevent accidental app hiding: bidirectional coupling between Hide from Taskbar and Show Tray Stats
     // If user enables "Hide from Taskbar", automatically enable "Show Tray Stats" (ensures tray icon is visible)
     elements.minimizeToTrayToggle.addEventListener('change', () => {
@@ -461,7 +607,7 @@ function setupEventListeners() {
         }
         await loadSettings();
         elements.settingsOverlay.style.display = 'flex';
-        window.electronAPI.resizeWindow(318);
+        window.electronAPI.resizeWindow(SETTINGS_HEIGHT);
     });
 
     // Close compact settings — apply compact toggle value then close
@@ -1838,6 +1984,16 @@ async function loadSettings() {
     warnThreshold = settings.warnThreshold;
     dangerThreshold = settings.dangerThreshold;
 
+    // Re-apply, then seed the swatches from the values that actually took
+    // effect — applyStatusColors falls back to the defaults for anything
+    // missing or malformed, so the pickers can't show a color the app isn't
+    // using.
+    const colors = applyStatusColors(settings);
+    elements.warnColor.value = colors.warnColor;
+    elements.dangerColor.value = colors.dangerColor;
+    elements.elapsedWarnColor.value = colors.elapsedWarnColor;
+    elements.elapsedSoonColor.value = colors.elapsedSoonColor;
+
     elements.themeBtns.forEach(btn => {
         btn.classList.toggle('active', btn.dataset.theme === settings.theme);
     });
@@ -1855,6 +2011,8 @@ async function saveSettings() {
 
     warnThreshold = warn;
     dangerThreshold = danger;
+
+    const colors = readColorInputs();
 
     // Apply compact mode change first, then include in saved settings
     const compactToggleValue = elements.compactModeToggle.checked;
@@ -1876,11 +2034,15 @@ async function saveSettings() {
         usageAlerts: elements.usageAlertsToggle.checked,
         compactMode: isCompactMode,
         graphVisible: graphVisible,
-        expandedOpen: isExpanded
+        expandedOpen: isExpanded,
+        ...colors
     };
     await window.electronAPI.saveSettings(settings);
     window._cachedSettings = settings;
     applyTheme(settings.theme);
+    // Tray badges are drawn in the main process from the stored colors, so
+    // they only pick this up after the save above has landed.
+    applyStatusColors(settings);
     if (window.electronAPI.platform === 'darwin') {
         document.getElementById('trayLabel').textContent = 'Hide from Dock';
     }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -37,13 +37,65 @@ const ELAPSED_GREEN_THRESHOLD = 90;
 // 343 keeps the same slack around the block that six rows had.
 const SETTINGS_HEIGHT = 343;
 
-// Default status colors. Must stay in step with the :root block in styles.css
-// and with the same defaults in main.js's get-settings/save-settings handlers.
+// Height of the Colours page window. Measured against the running panel, like
+// SETTINGS_HEIGHT above — .colours-rows has no scrollbar, and because it is a
+// flex:1 child it silently grows past the window rather than reporting an
+// overflow, so an undersized value clips the bottom row with no other symptom.
+// 423 = 36px header + 375px of rows + 12px breathing room, measured.
+const COLOURS_HEIGHT = 423;
+
+// Default colors. Must stay in step with the :root block in styles.css and
+// with the same defaults in main.js's get-settings/save-settings handlers.
+//
+// Two kinds live here. STATUS colors say how full a bar is or how far through
+// a window a ring is; ROW colors say which row you are looking at. Keeping
+// them apart is what lets a row keep its identity while it warns.
 const DEFAULT_STATUS_COLORS = {
     warnColor: '#f59e0b',
     dangerColor: '#ef4444',
     elapsedWarnColor: '#f59e0b',
     elapsedSoonColor: '#10b981'
+};
+
+const DEFAULT_ROW_COLORS = {
+    sessionBarColor: '#8b5cf6',
+    sessionRingColor: '#8b5cf6',
+    weeklyBarColor: '#3b82f6',
+    weeklyRingColor: '#3b82f6',
+    fableBarColor: '#d946ef',
+    fableRingColor: '#d946ef',
+    spendBarColor: '#10b981'
+};
+
+// Every configurable color in one place, for the settings round-trip and the
+// "Reset to defaults" link.
+const DEFAULT_COLORS = { ...DEFAULT_STATUS_COLORS, ...DEFAULT_ROW_COLORS };
+
+// How the elapsed rings pick their 75%/90% colors.
+//   custom  — the two elapsedWarnColor/elapsedSoonColor pickers, one pair for
+//             every ring (what the app did before this existed)
+//   lighter — each ring stages through lighter shades of ITS OWN color
+//   darker  — the same, toward black
+// Default is 'custom', so upgrading changes nothing until it's switched.
+const ELAPSED_COLOR_MODES = ['custom', 'lighter', 'darker'];
+const DEFAULT_ELAPSED_MODE = 'custom';
+
+// How far to travel toward white/black, as a percentage of the distance
+// remaining, for each of the two stages. Configurable on the Colours page.
+const DEFAULT_ELAPSED_WARN_PERCENT = 66;
+const DEFAULT_ELAPSED_SOON_PERCENT = 80;
+
+// Ring base colors for the rows that aren't individually configurable. The
+// three that are (session/weekly/fable) come from settings instead. Keyed by
+// the color class buildExtraRows() puts on the ring, and kept in step with the
+// .timer-progress.* rules in styles.css.
+const EXTRA_RING_BASE_COLORS = {
+    opus: '#f59e0b',
+    sonnet: '#f43f5e',
+    cowork: '#06b6d4',
+    design: '#92400e',
+    oauth: '#f97316',
+    scoped: '#64748b'
 };
 
 // Debug logging — only shows in DevTools (development mode).
@@ -74,14 +126,18 @@ function hexToRgba(hex, alpha) {
 }
 
 // The gradient partners this app has always used. They are hand-picked
-// Tailwind steps (amber-500 -> amber-400, red-500 -> red-400) that shift hue
-// and saturation as well as lightness, so no single lighten formula
-// reproduces them. Kept as data rather than approximated, so an install that
-// never touches the pickers renders exactly as it always has; anything the
-// user picks falls through to lightenHex().
+// Tailwind steps (amber-500 -> amber-400, violet-500 -> violet-400, and so
+// on) that shift hue and saturation as well as lightness, so no single
+// lighten formula reproduces them. Kept as data rather than approximated, so
+// an install that never touches the pickers renders exactly as it always has;
+// anything the user picks falls through to lightenHex().
 const DEFAULT_LIGHT_STOPS = {
-    '#f59e0b': '#fbbf24',
-    '#ef4444': '#f87171'
+    '#f59e0b': '#fbbf24', // status warn
+    '#ef4444': '#f87171', // status danger
+    '#8b5cf6': '#a78bfa', // Current Session
+    '#3b82f6': '#60a5fa', // Weekly Limit
+    '#d946ef': '#e879f9', // Fable Weekly
+    '#10b981': '#34d399'  // Monthly Spend
 };
 
 function lightStopFor(hex) {
@@ -125,38 +181,226 @@ function lightenHex(hex, lightBy = 12, satBy = 5) {
     return `#${toHex(hueToRgb(p, q, h + 1 / 3))}${toHex(hueToRgb(p, q, h))}${toHex(hueToRgb(p, q, h - 1 / 3))}`;
 }
 
+// Move a color's lightness a percentage of the distance REMAINING to white or
+// black, holding hue and saturation. Proportional rather than a fixed step, so
+// a color already near the target barely moves and one far away moves a lot —
+// which is what keeps the two stages distinguishable whatever the base is.
+//
+//   toward 'white': L + (100 - L) * pct/100
+//   toward 'black': L - L * pct/100
+//
+// Deliberately unclamped: at high percentages this can produce a ring with
+// almost no contrast against the theme background. That is the specified
+// behaviour, and the percentages are the user's dial for it.
+function hslShift(hex, pct, toward = 'white') {
+    const rgb = hexToRgb(hex);
+    if (!rgb) return hex;
+    const r = rgb.r / 255, g = rgb.g / 255, b = rgb.b / 255;
+    const max = Math.max(r, g, b), min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    let h = 0, s = 0;
+    if (max !== min) {
+        const d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+        else if (max === g) h = ((b - r) / d + 2) / 6;
+        else h = ((r - g) / d + 4) / 6;
+    }
+    const target = toward === 'black' ? 0 : 1;
+    const l2 = Math.min(1, Math.max(0, l + (target - l) * (pct / 100)));
+
+    const hueToRgb = (p, q, t) => {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1 / 6) return p + (q - p) * 6 * t;
+        if (t < 1 / 2) return q;
+        if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+        return p;
+    };
+    const q = l2 < 0.5 ? l2 * (1 + s) : l2 + s - l2 * s;
+    const p = 2 * l2 - q;
+    const toHex = (v) => Math.round(v * 255).toString(16).padStart(2, '0');
+    return `#${toHex(hueToRgb(p, q, h + 1 / 3))}${toHex(hueToRgb(p, q, h))}${toHex(hueToRgb(p, q, h - 1 / 3))}`;
+}
+
+// The elapsed pair a given ring should use, given the mode. In custom mode
+// every ring shares the two picked colors; otherwise each derives its own from
+// the color it already is.
+function elapsedPairFor(baseHex, prefs) {
+    if (prefs.mode !== 'lighter' && prefs.mode !== 'darker') {
+        return { warn: prefs.elapsedWarnColor, soon: prefs.elapsedSoonColor };
+    }
+    const toward = prefs.mode === 'lighter' ? 'white' : 'black';
+    return {
+        warn: hslShift(baseHex, prefs.warnPercent, toward),
+        soon: hslShift(baseHex, prefs.soonPercent, toward)
+    };
+}
+
+// Normalize a settings object into the values actually used, falling back to
+// defaults for anything missing or malformed. Single place that decides what
+// "the current colors" are, so the CSS, the pickers and the previews can't
+// disagree about it.
+function resolveColorPrefs(settings = {}) {
+    const colors = { ...DEFAULT_COLORS };
+    for (const key of Object.keys(DEFAULT_COLORS)) {
+        if (hexToRgb(settings[key])) colors[key] = String(settings[key]).toLowerCase();
+    }
+    const mode = ELAPSED_COLOR_MODES.includes(settings.elapsedColorMode)
+        ? settings.elapsedColorMode
+        : DEFAULT_ELAPSED_MODE;
+    const pct = (value, fallback) => {
+        const n = Number(value);
+        return Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : fallback;
+    };
+    return {
+        ...colors,
+        mode,
+        warnPercent: pct(settings.elapsedWarnPercent, DEFAULT_ELAPSED_WARN_PERCENT),
+        soonPercent: pct(settings.elapsedSoonPercent, DEFAULT_ELAPSED_SOON_PERCENT)
+    };
+}
+
 // Push the chosen colors into the CSS custom properties that styles.css reads.
-// Everything colored by threshold state — expanded bars, compact bars and the
-// elapsed rings — follows from these, so there is one write per state rather
-// than a sweep over elements.
+// Everything colored by threshold state or row identity — expanded bars,
+// compact bars and the rings — follows from these, so there is one write per
+// value rather than a sweep over elements.
+//
+// The one exception is the elapsed pair in lighter/darker mode, which differs
+// per row and so is written onto the rows themselves by
+// applyElapsedRingColors() below.
 function applyStatusColors(settings = {}) {
-    const colors = { ...DEFAULT_STATUS_COLORS };
-    for (const key of Object.keys(DEFAULT_STATUS_COLORS)) {
-        if (hexToRgb(settings[key])) colors[key] = settings[key];
+    const prefs = resolveColorPrefs(settings);
+    const root = document.documentElement;
+
+    root.style.setProperty('--status-warn', prefs.warnColor);
+    root.style.setProperty('--status-warn-light', lightStopFor(prefs.warnColor));
+    root.style.setProperty('--status-warn-glow', hexToRgba(prefs.warnColor, 0.3));
+    root.style.setProperty('--status-danger', prefs.dangerColor);
+    root.style.setProperty('--status-danger-light', lightStopFor(prefs.dangerColor));
+    root.style.setProperty('--status-danger-glow', hexToRgba(prefs.dangerColor, 0.3));
+
+    // Row identity: bars need base + light stop + glow, rings just a base.
+    const bars = [
+        ['session', prefs.sessionBarColor],
+        ['weekly', prefs.weeklyBarColor],
+        ['fable', prefs.fableBarColor],
+        ['spend', prefs.spendBarColor]
+    ];
+    for (const [name, hex] of bars) {
+        root.style.setProperty(`--row-${name}`, hex);
+        root.style.setProperty(`--row-${name}-light`, lightStopFor(hex));
+        root.style.setProperty(`--row-${name}-glow`, hexToRgba(hex, 0.3));
+    }
+    root.style.setProperty('--ring-session', prefs.sessionRingColor);
+    root.style.setProperty('--ring-weekly', prefs.weeklyRingColor);
+    root.style.setProperty('--ring-fable', prefs.fableRingColor);
+
+    // Custom mode: one pair for every ring, set globally. In lighter/darker
+    // these are still written as the fallback, but every row overrides them.
+    root.style.setProperty('--elapsed-warn', prefs.elapsedWarnColor);
+    root.style.setProperty('--elapsed-soon', prefs.elapsedSoonColor);
+
+    applyElapsedRingColors(prefs);
+    return prefs;
+}
+
+// Scope the elapsed pair per row. CSS custom properties inherit, so setting
+// them on a row element is enough for that row's ring to pick them up — the
+// .timer-progress.elapsed-* rules never change.
+function applyElapsedRingColors(prefs) {
+    const perRow = prefs.mode === 'lighter' || prefs.mode === 'darker';
+
+    const rowBase = [
+        [elements.sessionSection, prefs.sessionRingColor],
+        [elements.weeklySection, prefs.weeklyRingColor],
+        [elements.fableSection, prefs.fableRingColor]
+    ];
+
+    // Extra rows carry their identity in a class on the ring, and their base
+    // colors aren't user-configurable, so look them up rather than reading
+    // back a computed stroke that may already be a derived color.
+    for (const row of Array.from(elements.extraRows.children)) {
+        const ring = row.querySelector('.timer-progress');
+        if (!ring) continue; // Monthly Spend has a bar but no countdown ring
+        const cls = Object.keys(EXTRA_RING_BASE_COLORS).find(c => ring.classList.contains(c));
+        rowBase.push([row, EXTRA_RING_BASE_COLORS[cls] || DEFAULT_ROW_COLORS.sessionRingColor]);
     }
 
-    const root = document.documentElement;
-    root.style.setProperty('--status-warn', colors.warnColor);
-    root.style.setProperty('--status-warn-light', lightStopFor(colors.warnColor));
-    root.style.setProperty('--status-warn-glow', hexToRgba(colors.warnColor, 0.3));
-    root.style.setProperty('--status-danger', colors.dangerColor);
-    root.style.setProperty('--status-danger-light', lightStopFor(colors.dangerColor));
-    root.style.setProperty('--status-danger-glow', hexToRgba(colors.dangerColor, 0.3));
-    root.style.setProperty('--elapsed-warn', colors.elapsedWarnColor);
-    root.style.setProperty('--elapsed-soon', colors.elapsedSoonColor);
-
-    return colors;
+    for (const [row, base] of rowBase) {
+        if (!row) continue;
+        if (!perRow) {
+            // Fall back to the global pair rather than leaving a stale override.
+            row.style.removeProperty('--elapsed-warn');
+            row.style.removeProperty('--elapsed-soon');
+            continue;
+        }
+        const pair = elapsedPairFor(base, prefs);
+        row.style.setProperty('--elapsed-warn', pair.warn);
+        row.style.setProperty('--elapsed-soon', pair.soon);
+    }
 }
 
 // Current picker values, falling back to the defaults for any input that is
 // missing (older cached markup) or holding something unparseable.
 function readColorInputs() {
     const colors = {};
-    for (const key of Object.keys(DEFAULT_STATUS_COLORS)) {
+    for (const key of Object.keys(DEFAULT_COLORS)) {
         const value = elements[key] ? elements[key].value : null;
-        colors[key] = hexToRgb(value) ? value.toLowerCase() : DEFAULT_STATUS_COLORS[key];
+        colors[key] = hexToRgb(value) ? value.toLowerCase() : DEFAULT_COLORS[key];
     }
+
+    const checked = Array.from(elements.elapsedModeRadios || []).find(r => r.checked);
+    colors.elapsedColorMode = checked && ELAPSED_COLOR_MODES.includes(checked.value)
+        ? checked.value
+        : DEFAULT_ELAPSED_MODE;
+
+    const percent = (el, fallback) => {
+        const n = parseInt(el ? el.value : '', 10);
+        return Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : fallback;
+    };
+    colors.elapsedWarnPercent = percent(elements.elapsedWarnPercent, DEFAULT_ELAPSED_WARN_PERCENT);
+    colors.elapsedSoonPercent = percent(elements.elapsedSoonPercent, DEFAULT_ELAPSED_SOON_PERCENT);
+
     return colors;
+}
+
+// Mirror the current colour state into the Colours page: seed every control,
+// grey out the rows the selected mode doesn't use, and repaint the per-row
+// preview strips.
+function syncColoursPage(prefs) {
+    for (const key of Object.keys(DEFAULT_COLORS)) {
+        if (elements[key]) elements[key].value = prefs[key];
+    }
+    for (const radio of elements.elapsedModeRadios || []) {
+        radio.checked = radio.value === prefs.mode;
+    }
+    if (elements.elapsedWarnPercent) elements.elapsedWarnPercent.value = prefs.warnPercent;
+    if (elements.elapsedSoonPercent) elements.elapsedSoonPercent.value = prefs.soonPercent;
+
+    // Custom colours only apply in custom mode; the percentages only apply in
+    // the derived modes. Disabling rather than hiding keeps the panel height
+    // steady as the mode changes.
+    const derived = prefs.mode === 'lighter' || prefs.mode === 'darker';
+    if (elements.elapsedCustomRow) elements.elapsedCustomRow.classList.toggle('is-disabled', derived);
+    if (elements.elapsedPercentRow) elements.elapsedPercentRow.classList.toggle('is-disabled', !derived);
+
+    const previews = [
+        [elements.sessionPreview, prefs.sessionRingColor],
+        [elements.weeklyPreview, prefs.weeklyRingColor],
+        [elements.fablePreview, prefs.fableRingColor]
+    ];
+    for (const [host, base] of previews) {
+        if (!host) continue;
+        const pair = elapsedPairFor(base, prefs);
+        host.innerHTML = '';
+        for (const [hex, label] of [[base, 'base'], [pair.warn, '75% elapsed'], [pair.soon, '90% elapsed']]) {
+            const chip = document.createElement('span');
+            chip.style.background = hex;
+            chip.title = `${label}: ${hex}`;
+            host.appendChild(chip);
+        }
+    }
 }
 
 // DOM elements
@@ -191,6 +435,8 @@ const elements = {
     weeklyTimeText: document.getElementById('weeklyTimeText'),
     weeklyResetsAt: document.getElementById('weeklyResetsAt'),
 
+    sessionSection: document.getElementById('sessionSection'),
+    weeklySection: document.getElementById('weeklySection'),
     fableSection: document.getElementById('fableSection'),
     fablePercentage: document.getElementById('fablePercentage'),
     fableProgress: document.getElementById('fableProgress'),
@@ -220,11 +466,32 @@ const elements = {
     showTrayStatsToggle: document.getElementById('showTrayStatsToggle'),
     warnThreshold: document.getElementById('warnThreshold'),
     dangerThreshold: document.getElementById('dangerThreshold'),
+    // Colour pickers — all live on the Colours page. Keyed by settings name so
+    // the read/apply loops can iterate DEFAULT_COLORS directly.
     warnColor: document.getElementById('warnColor'),
     dangerColor: document.getElementById('dangerColor'),
     elapsedWarnColor: document.getElementById('elapsedWarnColor'),
     elapsedSoonColor: document.getElementById('elapsedSoonColor'),
+    sessionBarColor: document.getElementById('sessionBarColor'),
+    sessionRingColor: document.getElementById('sessionRingColor'),
+    weeklyBarColor: document.getElementById('weeklyBarColor'),
+    weeklyRingColor: document.getElementById('weeklyRingColor'),
+    fableBarColor: document.getElementById('fableBarColor'),
+    fableRingColor: document.getElementById('fableRingColor'),
+    spendBarColor: document.getElementById('spendBarColor'),
+
+    coloursBtn: document.getElementById('coloursBtn'),
+    coloursOverlay: document.getElementById('coloursOverlay'),
+    closeColoursBtn: document.getElementById('closeColoursBtn'),
     resetColorsLink: document.getElementById('resetColorsLink'),
+    elapsedModeRadios: document.querySelectorAll('input[name="elapsedMode"]'),
+    elapsedCustomRow: document.getElementById('elapsedCustomRow'),
+    elapsedPercentRow: document.getElementById('elapsedPercentRow'),
+    elapsedWarnPercent: document.getElementById('elapsedWarnPercent'),
+    elapsedSoonPercent: document.getElementById('elapsedSoonPercent'),
+    sessionPreview: document.getElementById('sessionPreview'),
+    weeklyPreview: document.getElementById('weeklyPreview'),
+    fablePreview: document.getElementById('fablePreview'),
     themeBtns: document.querySelectorAll('.theme-btn'),
     timeFormat: document.getElementById('timeFormat'),
     weeklyDateFormat: document.getElementById('weeklyDateFormat'),
@@ -461,6 +728,7 @@ function setupEventListeners() {
     elements.closeSettingsBtn.addEventListener('click', async () => {
         await saveSettings();
         elements.settingsOverlay.style.display = 'none';
+        if (elements.coloursOverlay) elements.coloursOverlay.style.display = 'none';
         if (_settingsOpenedFromCompact) {
             _settingsOpenedFromCompact = false;
             if (isCompactMode) {
@@ -494,21 +762,52 @@ function setupEventListeners() {
         });
     });
 
-    // Color pickers — repaint live while the OS picker is open so the choice
-    // can be judged against real bars. Like the theme buttons and the
-    // threshold numbers, nothing is persisted until Done (saveSettings).
-    // Tray badges are drawn in the main process and so only follow on Done.
-    for (const key of Object.keys(DEFAULT_STATUS_COLORS)) {
-        if (!elements[key]) continue;
-        elements[key].addEventListener('input', () => applyStatusColors(readColorInputs()));
+    // Colours page — opened from Settings, and closed straight back to it, so
+    // the Settings overlay is left showing underneath rather than dismissed.
+    if (elements.coloursBtn) {
+        elements.coloursBtn.addEventListener('click', () => {
+            syncColoursPage(resolveColorPrefs(readColorInputs()));
+            elements.coloursOverlay.style.display = 'flex';
+            window.electronAPI.resizeWindow(COLOURS_HEIGHT);
+        });
+    }
+
+    if (elements.closeColoursBtn) {
+        elements.closeColoursBtn.addEventListener('click', () => {
+            elements.coloursOverlay.style.display = 'none';
+            window.electronAPI.resizeWindow(SETTINGS_HEIGHT);
+        });
+    }
+
+    // Every colour control repaints live so the choice can be judged against
+    // real bars and rings behind the panel. Like the theme buttons and the
+    // threshold numbers, nothing is persisted until Done in Settings
+    // (saveSettings). Tray badges are drawn in the main process, so those
+    // follow only once the save lands.
+    const repaint = () => {
+        const prefs = applyStatusColors(readColorInputs());
+        syncColoursPage(prefs);
+    };
+    for (const key of Object.keys(DEFAULT_COLORS)) {
+        if (elements[key]) elements[key].addEventListener('input', repaint);
+    }
+    for (const radio of elements.elapsedModeRadios || []) {
+        radio.addEventListener('change', repaint);
+    }
+    for (const el of [elements.elapsedWarnPercent, elements.elapsedSoonPercent]) {
+        if (el) el.addEventListener('input', repaint);
     }
 
     if (elements.resetColorsLink) {
         elements.resetColorsLink.addEventListener('click', () => {
-            for (const [key, value] of Object.entries(DEFAULT_STATUS_COLORS)) {
-                if (elements[key]) elements[key].value = value;
-            }
-            applyStatusColors(DEFAULT_STATUS_COLORS);
+            const defaults = {
+                ...DEFAULT_COLORS,
+                elapsedColorMode: DEFAULT_ELAPSED_MODE,
+                elapsedWarnPercent: DEFAULT_ELAPSED_WARN_PERCENT,
+                elapsedSoonPercent: DEFAULT_ELAPSED_SOON_PERCENT
+            };
+            syncColoursPage(resolveColorPrefs(defaults));
+            applyStatusColors(defaults);
         });
     }
 
@@ -992,6 +1291,12 @@ function buildExtraRows(data) {
         elements.expandArrow.classList.remove('expanded');
         elements.expandSection.style.display = 'none';
     }
+
+    // These rows are rebuilt from scratch on every refresh, so their per-row
+    // elapsed overrides have to be re-applied here rather than only when
+    // settings change — otherwise a lighter/darker ring reverts to the global
+    // pair on the next fetch.
+    applyElapsedRingColors(resolveColorPrefs(window._cachedSettings || {}));
 
     return count;
 }
@@ -1594,6 +1899,7 @@ function showLoginRequired() {
     elements.sessionKeyInput.value = '';
     // Close any open overlays
     elements.settingsOverlay.style.display = 'none';
+    if (elements.coloursOverlay) elements.coloursOverlay.style.display = 'none';
     elements.compactSettingsOverlay.style.display = 'none';
     // Hide header buttons during login
     elements.settingsBtn.style.display = 'none';
@@ -1988,11 +2294,7 @@ async function loadSettings() {
     // effect — applyStatusColors falls back to the defaults for anything
     // missing or malformed, so the pickers can't show a color the app isn't
     // using.
-    const colors = applyStatusColors(settings);
-    elements.warnColor.value = colors.warnColor;
-    elements.dangerColor.value = colors.dangerColor;
-    elements.elapsedWarnColor.value = colors.elapsedWarnColor;
-    elements.elapsedSoonColor.value = colors.elapsedSoonColor;
+    syncColoursPage(applyStatusColors(settings));
 
     elements.themeBtns.forEach(btn => {
         btn.classList.toggle('active', btn.dataset.theme === settings.theme);

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -38,13 +38,14 @@ const ELAPSED_GREEN_THRESHOLD = 90;
 const SETTINGS_HEIGHT = 343;
 
 // Height of the Colours page window. Measured in the running app, like
-// SETTINGS_HEIGHT above: 36px header + 261px of rows + 24px breathing room.
+// SETTINGS_HEIGHT above. Re-measure this whenever a row is added: the column
+// heads row cost 19px and took the previous 321 seven pixels short.
 //
 // .colours-rows has no scrollbar, and because it is a flex:1 child it grows
 // past the window rather than reporting an overflow — scrollHeight and
 // clientHeight agree even when the bottom row sits below the window edge. The
 // check that actually works is the last row's bottom against innerHeight.
-const COLOURS_HEIGHT = 321;
+const COLOURS_HEIGHT = 340;
 
 // Default colors. Must stay in step with the :root block in styles.css and
 // with the same defaults in main.js's get-settings/save-settings handlers.

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -475,7 +475,7 @@
                         </div>
                         <div class="colour-row">
                             <span class="colour-row-label">Monthly Spend</span>
-                            <input type="color" id="spendBarColor" class="threshold-dot" value="#10b981" title="Monthly Spend bar">
+                            <input type="color" id="spendBarColor" class="threshold-dot" value="#bc1010" title="Monthly Spend bar">
                             <!-- Spacers: the spend row has a bar but no countdown ring. -->
                             <span class="threshold-dot colour-slot-empty"></span>
                             <span class="colour-preview colour-preview-empty"></span>
@@ -495,8 +495,8 @@
                         <div class="colour-row colour-row--wide">
                             <span class="colour-row-label">Mode</span>
                             <div class="colour-row-controls">
-                                <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeCustom" value="custom" checked> Custom</label>
-                                <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeLighter" value="lighter"> Lighter</label>
+                                <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeCustom" value="custom"> Custom</label>
+                                <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeLighter" value="lighter" checked> Lighter</label>
                                 <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeDarker" value="darker"> Darker</label>
                             </div>
                         </div>
@@ -509,9 +509,9 @@
                         <div class="colour-row colour-row--wide" id="elapsedPercentRow">
                             <span class="colour-row-label">Shift by</span>
                             <div class="colour-row-controls">
-                                <input type="number" id="elapsedWarnPercent" class="threshold-input" min="0" max="100" value="66">
+                                <input type="number" id="elapsedWarnPercent" class="threshold-input" min="0" max="100" value="20">
                                 <span class="threshold-pct">%</span>
-                                <input type="number" id="elapsedSoonPercent" class="threshold-input" min="0" max="100" value="80">
+                                <input type="number" id="elapsedSoonPercent" class="threshold-input" min="0" max="100" value="40">
                                 <span class="threshold-pct">%</span>
                                 <span class="colour-row-hint">of the way to white / black</span>
                             </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -364,21 +364,48 @@
                             <div class="settings-col">
                                 <span class="settings-row-label">Warn at</span>
                                 <div class="threshold-group">
-                                    <label class="threshold-label">
-                                        <span class="threshold-dot warning-dot"></span>
+                                    <!-- Plain divs, not labels: an implicit <label> wrapping two
+                                         controls binds to the first one, so clicking the number
+                                         field would pop the color picker. -->
+                                    <div class="threshold-label">
+                                        <input type="color" id="warnColor" class="threshold-dot" value="#f59e0b" title="Warning color">
                                         <input type="number" id="warnThreshold" class="threshold-input" min="1" max="99" value="75">
                                         <span class="threshold-pct">%</span>
-                                    </label>
-                                    <label class="threshold-label">
-                                        <span class="threshold-dot danger-dot"></span>
+                                    </div>
+                                    <div class="threshold-label">
+                                        <input type="color" id="dangerColor" class="threshold-dot" value="#ef4444" title="Danger color">
                                         <input type="number" id="dangerThreshold" class="threshold-input" min="1" max="99" value="90">
                                         <span class="threshold-pct">%</span>
-                                    </label>
+                                    </div>
                                 </div>
                             </div>
                         </div>
 
-                        <!-- Row 6: date format + auto refresh -->
+                        <!-- Row 6: elapsed-ring colors + reset.
+                             The 75/90 thresholds are fixed (see ELAPSED_AMBER_THRESHOLD /
+                             ELAPSED_GREEN_THRESHOLD in app.js) — shown here as static text
+                             so it's clear which stage each swatch paints. -->
+                        <div class="settings-row-2col">
+                            <div class="settings-col">
+                                <span class="settings-row-label">Elapsed ring</span>
+                                <div class="threshold-group">
+                                    <div class="threshold-label">
+                                        <input type="color" id="elapsedWarnColor" class="threshold-dot" value="#f59e0b" title="Ring color from 75% elapsed">
+                                        <span class="threshold-fixed">75%</span>
+                                    </div>
+                                    <div class="threshold-label">
+                                        <input type="color" id="elapsedSoonColor" class="threshold-dot" value="#10b981" title="Ring color from 90% elapsed">
+                                        <span class="threshold-fixed">90%</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="settings-col">
+                                <span class="settings-row-label">Colors</span>
+                                <span class="color-reset-link" id="resetColorsLink">Reset to defaults</span>
+                            </div>
+                        </div>
+
+                        <!-- Row 7: date format + auto refresh -->
                         <div class="settings-row-2col">
                             <div class="settings-col">
                                 <span class="settings-row-label">Date format</span>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -170,6 +170,29 @@
                     <div class="resets-at-text" id="weeklyResetsAt">--</div>
                 </div>
 
+                <!-- Fable Weekly — a primary row, not an expansion row, so it gets the
+                     same size and weight as Session and Weekly above. Hidden unless the
+                     account actually has a scoped Fable weekly limit; the compact-mode
+                     Fable row below follows the same hidden-by-default pattern. -->
+                <div class="usage-section" id="fableSection" style="display: none;">
+                    <span class="usage-label">Fable Weekly</span>
+                    <div class="usage-bar-group">
+                        <div class="progress-bar">
+                            <div class="progress-fill fable" id="fableProgress" style="width: 0%"></div>
+                        </div>
+                        <span class="usage-percentage" id="fablePercentage">0%</span>
+                    </div>
+                    <div class="usage-elapsed-group">
+                        <svg class="mini-timer" width="24" height="24" viewBox="0 0 24 24">
+                            <circle class="timer-bg" cx="12" cy="12" r="10" />
+                            <circle class="timer-progress fable" id="fableTimer" cx="12" cy="12" r="10"
+                                style="stroke-dasharray: 63; stroke-dashoffset: 63" />
+                        </svg>
+                    </div>
+                    <div class="timer-text" id="fableTimeText">--:--</div>
+                    <div class="resets-at-text" id="fableResetsAt">--</div>
+                </div>
+
                 <!-- Expand Toggle -->
                 <div class="expand-toggle" id="expandToggle">
                     <svg class="expand-arrow" id="expandArrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -131,7 +131,7 @@
                 </div>
 
                 <!-- Session Usage -->
-                <div class="usage-section">
+                <div class="usage-section" id="sessionSection">
                     <span class="usage-label">Current Session</span>
                     <div class="usage-bar-group">
                         <div class="progress-bar">
@@ -151,7 +151,7 @@
                 </div>
 
                 <!-- Weekly Usage -->
-                <div class="usage-section">
+                <div class="usage-section" id="weeklySection">
                     <span class="usage-label">Weekly Limit</span>
                     <div class="usage-bar-group">
                         <div class="progress-bar">
@@ -364,16 +364,15 @@
                             <div class="settings-col">
                                 <span class="settings-row-label">Warn at</span>
                                 <div class="threshold-group">
-                                    <!-- Plain divs, not labels: an implicit <label> wrapping two
-                                         controls binds to the first one, so clicking the number
-                                         field would pop the color picker. -->
+                                    <!-- Thresholds only. The colors these states paint live on
+                                         the Colours page, alongside every other color. -->
                                     <div class="threshold-label">
-                                        <input type="color" id="warnColor" class="threshold-dot" value="#f59e0b" title="Warning color">
+                                        <span class="threshold-swatch" id="warnThresholdSwatch"></span>
                                         <input type="number" id="warnThreshold" class="threshold-input" min="1" max="99" value="75">
                                         <span class="threshold-pct">%</span>
                                     </div>
                                     <div class="threshold-label">
-                                        <input type="color" id="dangerColor" class="threshold-dot" value="#ef4444" title="Danger color">
+                                        <span class="threshold-swatch" id="dangerThresholdSwatch"></span>
                                         <input type="number" id="dangerThreshold" class="threshold-input" min="1" max="99" value="90">
                                         <span class="threshold-pct">%</span>
                                     </div>
@@ -381,28 +380,14 @@
                             </div>
                         </div>
 
-                        <!-- Row 6: elapsed-ring colors + reset.
-                             The 75/90 thresholds are fixed (see ELAPSED_AMBER_THRESHOLD /
-                             ELAPSED_GREEN_THRESHOLD in app.js) — shown here as static text
-                             so it's clear which stage each swatch paints. -->
+                        <!-- Row 6: colours page + theme-wide reset. Every color the app
+                             uses lives behind this button, so this panel stays short. -->
                         <div class="settings-row-2col">
                             <div class="settings-col">
-                                <span class="settings-row-label">Elapsed ring</span>
-                                <div class="threshold-group">
-                                    <div class="threshold-label">
-                                        <input type="color" id="elapsedWarnColor" class="threshold-dot" value="#f59e0b" title="Ring color from 75% elapsed">
-                                        <span class="threshold-fixed">75%</span>
-                                    </div>
-                                    <div class="threshold-label">
-                                        <input type="color" id="elapsedSoonColor" class="threshold-dot" value="#10b981" title="Ring color from 90% elapsed">
-                                        <span class="threshold-fixed">90%</span>
-                                    </div>
-                                </div>
+                                <span class="settings-row-label">Colours</span>
+                                <button class="colours-open-btn" id="coloursBtn">Customise…</button>
                             </div>
-                            <div class="settings-col">
-                                <span class="settings-row-label">Colors</span>
-                                <span class="color-reset-link" id="resetColorsLink">Reset to defaults</span>
-                            </div>
+                            <div class="settings-col"></div>
                         </div>
 
                         <!-- Row 7: date format + auto refresh -->
@@ -447,6 +432,84 @@
                     </div>
                 </div>
             </div>
+            <!-- Colours Overlay — every configurable colour in one place, reached from
+                 Settings. Each row's swatches sit next to a live [base][75%][90%] strip
+                 previewing how that row's elapsed ring will stage, which is the only way
+                 to show Lighter/Darker: those modes derive a different pair per row, so
+                 there is no single colour a shared swatch could display. -->
+            <div class="settings-overlay colours-overlay" id="coloursOverlay" style="display: none;">
+                <div class="settings-content">
+                    <div class="settings-header">
+                        <span class="settings-title">Colours</span>
+                        <button class="done-settings-btn" id="closeColoursBtn" title="Back to settings">Back</button>
+                    </div>
+
+                    <div class="settings-rows colours-rows">
+                        <div class="colours-heading">Rows<span class="colours-heading-hint">bar · ring · elapsed preview</span></div>
+
+                        <div class="colour-row">
+                            <span class="colour-row-label">Current Session</span>
+                            <input type="color" id="sessionBarColor" class="threshold-dot" value="#8b5cf6" title="Current Session bar">
+                            <input type="color" id="sessionRingColor" class="threshold-dot" value="#8b5cf6" title="Current Session elapsed ring">
+                            <span class="colour-preview" id="sessionPreview"></span>
+                        </div>
+                        <div class="colour-row">
+                            <span class="colour-row-label">Weekly Limit</span>
+                            <input type="color" id="weeklyBarColor" class="threshold-dot" value="#3b82f6" title="Weekly Limit bar">
+                            <input type="color" id="weeklyRingColor" class="threshold-dot" value="#3b82f6" title="Weekly Limit elapsed ring">
+                            <span class="colour-preview" id="weeklyPreview"></span>
+                        </div>
+                        <div class="colour-row">
+                            <span class="colour-row-label">Fable Weekly</span>
+                            <input type="color" id="fableBarColor" class="threshold-dot" value="#d946ef" title="Fable Weekly bar">
+                            <input type="color" id="fableRingColor" class="threshold-dot" value="#d946ef" title="Fable Weekly elapsed ring">
+                            <span class="colour-preview" id="fablePreview"></span>
+                        </div>
+                        <div class="colour-row">
+                            <span class="colour-row-label">Monthly Spend</span>
+                            <input type="color" id="spendBarColor" class="threshold-dot" value="#10b981" title="Monthly Spend bar">
+                            <!-- Spacers: the spend row has a bar but no countdown ring. -->
+                            <span class="threshold-dot colour-slot-empty"></span>
+                            <span class="colour-preview colour-preview-empty"></span>
+                        </div>
+
+                        <div class="colours-heading">Usage thresholds</div>
+                        <div class="colour-row">
+                            <span class="colour-row-label">Warn / Danger</span>
+                            <input type="color" id="warnColor" class="threshold-dot" value="#f59e0b" title="Colour at the Warn at threshold">
+                            <input type="color" id="dangerColor" class="threshold-dot" value="#ef4444" title="Colour at the Danger threshold">
+                            <span class="colour-row-hint">bars only — set the percentages in Settings</span>
+                        </div>
+
+                        <div class="colours-heading">Elapsed ring staging</div>
+                        <div class="colour-row">
+                            <span class="colour-row-label">Mode</span>
+                            <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeCustom" value="custom" checked> Custom</label>
+                            <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeLighter" value="lighter"> Lighter</label>
+                            <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeDarker" value="darker"> Darker</label>
+                        </div>
+                        <div class="colour-row" id="elapsedCustomRow">
+                            <span class="colour-row-label">Custom colours</span>
+                            <input type="color" id="elapsedWarnColor" class="threshold-dot" value="#f59e0b" title="Ring colour from 75% elapsed">
+                            <input type="color" id="elapsedSoonColor" class="threshold-dot" value="#10b981" title="Ring colour from 90% elapsed">
+                            <span class="colour-row-hint">at 75% and 90% elapsed</span>
+                        </div>
+                        <div class="colour-row" id="elapsedPercentRow">
+                            <span class="colour-row-label">Shift by</span>
+                            <input type="number" id="elapsedWarnPercent" class="threshold-input" min="0" max="100" value="66">
+                            <span class="threshold-pct">%</span>
+                            <input type="number" id="elapsedSoonPercent" class="threshold-input" min="0" max="100" value="80">
+                            <span class="threshold-pct">%</span>
+                            <span class="colour-row-hint">of the way to white / black</span>
+                        </div>
+
+                        <div class="colour-row">
+                            <span class="colour-reset-link" id="resetColorsLink">Reset all colours to defaults</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Compact Settings Overlay (shown only in compact mode) -->
             <div class="settings-overlay compact-settings-overlay" id="compactSettingsOverlay" style="display: none;">
                 <div class="settings-content">

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -445,7 +445,15 @@
                     </div>
 
                     <div class="settings-rows colours-rows">
-                        <div class="colours-heading">Rows<span class="colours-heading-hint">bar · ring · elapsed preview</span></div>
+                        <div class="colours-heading">Rows</div>
+                        <!-- Column heads share .colour-row's grid, so each sits directly
+                             above the swatch column it names. -->
+                        <div class="colour-row colour-row-heads">
+                            <span class="colour-row-label"></span>
+                            <span class="colour-col-head">Bar</span>
+                            <span class="colour-col-head">Ring</span>
+                            <span class="colour-col-head">Elapsed preview</span>
+                        </div>
 
                         <div class="colour-row">
                             <span class="colour-row-label">Current Session</span>
@@ -482,11 +490,15 @@
                         </div>
 
                         <div class="colours-heading">Elapsed ring staging</div>
-                        <div class="colour-row">
+                        <!-- Wide rows: their controls won't fit the narrow swatch columns,
+                             so they share only the label column and flex the rest. -->
+                        <div class="colour-row colour-row--wide">
                             <span class="colour-row-label">Mode</span>
-                            <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeCustom" value="custom" checked> Custom</label>
-                            <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeLighter" value="lighter"> Lighter</label>
-                            <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeDarker" value="darker"> Darker</label>
+                            <div class="colour-row-controls">
+                                <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeCustom" value="custom" checked> Custom</label>
+                                <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeLighter" value="lighter"> Lighter</label>
+                                <label class="radio-label"><input type="radio" name="elapsedMode" id="elapsedModeDarker" value="darker"> Darker</label>
+                            </div>
                         </div>
                         <div class="colour-row" id="elapsedCustomRow">
                             <span class="colour-row-label">Custom colours</span>
@@ -494,16 +506,18 @@
                             <input type="color" id="elapsedSoonColor" class="threshold-dot" value="#10b981" title="Ring colour from 90% elapsed">
                             <span class="colour-row-hint">at 75% and 90% elapsed</span>
                         </div>
-                        <div class="colour-row" id="elapsedPercentRow">
+                        <div class="colour-row colour-row--wide" id="elapsedPercentRow">
                             <span class="colour-row-label">Shift by</span>
-                            <input type="number" id="elapsedWarnPercent" class="threshold-input" min="0" max="100" value="66">
-                            <span class="threshold-pct">%</span>
-                            <input type="number" id="elapsedSoonPercent" class="threshold-input" min="0" max="100" value="80">
-                            <span class="threshold-pct">%</span>
-                            <span class="colour-row-hint">of the way to white / black</span>
+                            <div class="colour-row-controls">
+                                <input type="number" id="elapsedWarnPercent" class="threshold-input" min="0" max="100" value="66">
+                                <span class="threshold-pct">%</span>
+                                <input type="number" id="elapsedSoonPercent" class="threshold-input" min="0" max="100" value="80">
+                                <span class="threshold-pct">%</span>
+                                <span class="colour-row-hint">of the way to white / black</span>
+                            </div>
                         </div>
 
-                        <div class="colour-row">
+                        <div class="colour-row colour-row--wide">
                             <span class="colour-reset-link" id="resetColorsLink">Reset all colours to defaults</span>
                         </div>
                     </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -13,6 +13,31 @@
     src: url('../../assets/fonts/LibreBaskerville-Bold.ttf') format('truetype');
 }
 
+/* Status colors — single source of truth for the four threshold states.
+   The renderer overwrites these on document.documentElement from settings
+   (see applyStatusColors() in app.js); the values here are the defaults and
+   the fallback for the brief moment before settings load.
+
+   Each usage state needs three values because the bars are gradients with a
+   matching glow, but only the base is user-picked: app.js fills *-glow as the
+   base at 0.3 alpha, and *-light from its DEFAULT_LIGHT_STOPS table for the
+   two default colors (the hand-picked Tailwind partners below, which no
+   formula reproduces), falling back to an HSL lighten for anything else. The
+   defaults here are the literal colors this app has always used, so an
+   untouched install renders identically. */
+:root {
+    --status-warn: #f59e0b;
+    --status-warn-light: #fbbf24;
+    --status-warn-glow: rgba(245, 158, 11, 0.3);
+    --status-danger: #ef4444;
+    --status-danger-light: #f87171;
+    --status-danger-glow: rgba(239, 68, 68, 0.3);
+    /* Elapsed-time ring states — separate from the usage states above, so
+       recoloring "usage is high" never recolors "the window is nearly up". */
+    --elapsed-warn: #f59e0b;
+    --elapsed-soon: #10b981;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -685,15 +710,20 @@ body.theme-light .graph-btn.active {
     box-shadow: 0 0 10px rgba(249, 115, 22, 0.3);
 }
 
-/* Threshold color overrides for warning and danger states */
+/* Threshold color overrides for warning and danger states.
+   NOTE: a second copy of these two rules lives further down under
+   "Warning states" and wins on source order (it sets background but not
+   box-shadow, so the glow here still applies). Both are var()-driven, so
+   they stay in agreement; left duplicated rather than merged to keep the
+   diff against upstream small. */
 .progress-fill.warning {
-    background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%);
-    box-shadow: 0 0 10px rgba(245, 158, 11, 0.3);
+    background: linear-gradient(90deg, var(--status-warn) 0%, var(--status-warn-light) 100%);
+    box-shadow: 0 0 10px var(--status-warn-glow);
 }
 
 .progress-fill.danger {
-    background: linear-gradient(90deg, #ef4444 0%, #f87171 100%);
-    box-shadow: 0 0 10px rgba(239, 68, 68, 0.3);
+    background: linear-gradient(90deg, var(--status-danger) 0%, var(--status-danger-light) 100%);
+    box-shadow: 0 0 10px var(--status-danger-glow);
 }
 
 
@@ -1048,18 +1078,58 @@ body.theme-light .settings-disclaimer {
 }
 
 .threshold-dot {
-    width: 8px;
-    height: 8px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
     flex-shrink: 0;
 }
 
-.warning-dot {
-    background: #f59e0b;
+/* The threshold dots are <input type="color"> — clicking one opens the OS
+   color picker and recolors that state. The swatch fills from the input's own
+   value, so there is no background rule here; the pseudo-elements just strip
+   Chromium's default chrome so the control reads as a plain dot. 12px rather
+   than the 8px of the static span it replaced, because it is now a click
+   target. The faint ring keeps a near-black or near-white pick visible
+   against the panel. */
+input.threshold-dot {
+    -webkit-appearance: none;
+    appearance: none;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
 }
 
-.danger-dot {
-    background: #ef4444;
+input.threshold-dot::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+input.threshold-dot::-webkit-color-swatch {
+    border: none;
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+body.theme-light input.threshold-dot::-webkit-color-swatch {
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+/* Static "75%" / "90%" labels beside the elapsed-ring swatches — those
+   thresholds are fixed, only their colors are configurable. */
+.threshold-fixed {
+    color: #8080a0;
+    font-size: 11px;
+}
+
+.color-reset-link {
+    color: #8b5cf6;
+    font-size: 11px;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.color-reset-link:hover {
+    text-decoration: underline;
 }
 
 .threshold-input {
@@ -1269,25 +1339,27 @@ body.theme-light .settings-disclaimer {
     background: rgba(255, 255, 255, 0.2);
 }
 
-/* Warning states */
+/* Warning states — duplicate of the rules in the progress-bar section above;
+   see the note there. */
 .progress-fill.warning {
-    background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%);
+    background: linear-gradient(90deg, var(--status-warn) 0%, var(--status-warn-light) 100%);
 }
 
 .progress-fill.danger {
-    background: linear-gradient(90deg, #ef4444 0%, #f87171 100%);
+    background: linear-gradient(90deg, var(--status-danger) 0%, var(--status-danger-light) 100%);
 }
 
-/* Elapsed-time ring states — hardcoded, independent of the usage
-   warning/danger colors above. Amber at 75% elapsed is a neutral "heads up,
-   getting close to reset" cue, not an alarm. Green at 90% elapsed signals the
-   reset is imminent, which is a good thing, not a warning. */
+/* Elapsed-time ring states — independent of the usage warning/danger colors
+   above, and separately configurable. The thresholds stay fixed (75% / 90%
+   elapsed): amber is a neutral "heads up, getting close to reset" cue, not an
+   alarm, and green at 90% signals the reset is imminent, which is a good
+   thing. Only the two colors are user-chosen. */
 .timer-progress.elapsed-warn {
-    stroke: #f59e0b;
+    stroke: var(--elapsed-warn);
 }
 
 .timer-progress.elapsed-soon {
-    stroke: #10b981;
+    stroke: var(--elapsed-soon);
 }
 
 /* Light Theme */
@@ -1634,11 +1706,11 @@ body.theme-light .compact-expand-arrow {
 }
 
 .compact-bar-fill.warning {
-    background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%);
+    background: linear-gradient(90deg, var(--status-warn) 0%, var(--status-warn-light) 100%);
 }
 
 .compact-bar-fill.danger {
-    background: linear-gradient(90deg, #ef4444 0%, #f87171 100%);
+    background: linear-gradient(90deg, var(--status-danger) 0%, var(--status-danger-light) 100%);
 }
 
 .compact-pct {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1581,6 +1581,36 @@ body.theme-light .settings-row-label {
     color: #303050;
 }
 
+/* Colours page in the light theme. The dark-theme greys above are near-white
+   and vanish on a light panel, so every text style on that page needs a
+   counterpart here. */
+body.theme-light .colour-row-label,
+body.theme-light .radio-label {
+    color: #303050;
+}
+
+body.theme-light .colour-row-hint {
+    color: #606078;
+}
+
+body.theme-light .colours-heading {
+    color: #505060;
+}
+
+body.theme-light .colours-heading-hint {
+    color: #707088;
+}
+
+body.theme-light .colours-open-btn {
+    background: rgba(0, 0, 0, 0.05);
+    border-color: rgba(0, 0, 0, 0.15);
+    color: #303050;
+}
+
+body.theme-light .colours-open-btn:hover {
+    background: rgba(0, 0, 0, 0.1);
+}
+
 body.theme-light .settings-disclaimer {
     color: #9090a0;
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -33,9 +33,36 @@
     --status-danger-light: #f87171;
     --status-danger-glow: rgba(239, 68, 68, 0.3);
     /* Elapsed-time ring states — separate from the usage states above, so
-       recoloring "usage is high" never recolors "the window is nearly up". */
+       recoloring "usage is high" never recolors "the window is nearly up".
+
+       These two are also the only variables here that get set anywhere other
+       than :root. In Lighter/Darker mode each row derives its own pair from
+       its own ring color, and app.js sets them on the row element instead;
+       custom properties inherit, so each row's ring picks up its own values
+       and the :root pair below is what custom mode uses. */
     --elapsed-warn: #f59e0b;
     --elapsed-soon: #10b981;
+
+    /* Row identity colors — which row this is, as opposed to how full it is.
+       Bars are gradients with a matching glow so they need three values each
+       (see the note above); rings are a flat stroke and need only a base.
+       Session and Weekly also drive their tray badges, in main.js. */
+    --row-session: #8b5cf6;
+    --row-session-light: #a78bfa;
+    --row-session-glow: rgba(139, 92, 246, 0.3);
+    --row-weekly: #3b82f6;
+    --row-weekly-light: #60a5fa;
+    --row-weekly-glow: rgba(59, 130, 246, 0.3);
+    --row-fable: #d946ef;
+    --row-fable-light: #e879f9;
+    --row-fable-glow: rgba(217, 70, 239, 0.3);
+    --row-spend: #10b981;
+    --row-spend-light: #34d399;
+    --row-spend-glow: rgba(16, 185, 129, 0.3);
+
+    --ring-session: #8b5cf6;
+    --ring-weekly: #3b82f6;
+    --ring-fable: #d946ef;
 }
 
 * {
@@ -655,23 +682,24 @@ body.theme-light .graph-btn.active {
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #8b5cf6 0%, #a78bfa 100%);
+    background: linear-gradient(90deg, var(--row-session) 0%, var(--row-session-light) 100%);
     border-radius: 3px;
     transition: width 0.6s ease;
     position: relative;
-    box-shadow: 0 0 10px rgba(139, 92, 246, 0.3);
+    box-shadow: 0 0 10px var(--row-session-glow);
 }
 
 /* Shimmer removed */
 
 .progress-fill.weekly {
-    background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%);
-    box-shadow: 0 0 10px rgba(59, 130, 246, 0.3);
+    background: linear-gradient(90deg, var(--row-weekly) 0%, var(--row-weekly-light) 100%);
+    box-shadow: 0 0 10px var(--row-weekly-glow);
 }
 
+/* .extra is the Monthly Spend bar */
 .progress-fill.extra {
-    background: linear-gradient(90deg, #10b981 0%, #34d399 100%);
-    box-shadow: 0 0 10px rgba(16, 185, 129, 0.3);
+    background: linear-gradient(90deg, var(--row-spend) 0%, var(--row-spend-light) 100%);
+    box-shadow: 0 0 10px var(--row-spend-glow);
 }
 
 .progress-fill.opus {
@@ -685,8 +713,8 @@ body.theme-light .graph-btn.active {
 }
 
 .progress-fill.fable {
-    background: linear-gradient(90deg, #d946ef 0%, #e879f9 100%);
-    box-shadow: 0 0 10px rgba(217, 70, 239, 0.3);
+    background: linear-gradient(90deg, var(--row-fable) 0%, var(--row-fable-light) 100%);
+    box-shadow: 0 0 10px var(--row-fable-glow);
 }
 
 /* Fallback color for scoped weekly-limit models not statically configured */
@@ -749,17 +777,17 @@ body.theme-light .graph-btn.active {
 
 .timer-progress {
     fill: none;
-    stroke: #8b5cf6;
+    stroke: var(--ring-session);
     stroke-width: 4;
     transition: stroke-dashoffset 0.6s ease;
 }
 
 .timer-progress.weekly {
-    stroke: #3b82f6;
+    stroke: var(--ring-weekly);
 }
 
 .timer-progress.extra {
-    stroke: #10b981;
+    stroke: var(--row-spend);
 }
 
 .timer-progress.opus {
@@ -771,7 +799,7 @@ body.theme-light .graph-btn.active {
 }
 
 .timer-progress.fable {
-    stroke: #d946ef;
+    stroke: var(--ring-fable);
 }
 
 .timer-progress.scoped {
@@ -1121,14 +1149,152 @@ body.theme-light input.threshold-dot::-webkit-color-swatch {
     font-size: 11px;
 }
 
-.color-reset-link {
+/* Read-only dot beside each threshold number in Settings, showing which color
+   that state paints. The color itself is set on the Colours page; this just
+   points at it, so the two panels can't drift apart. */
+.threshold-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+#warnThresholdSwatch {
+    background: var(--status-warn);
+}
+
+#dangerThresholdSwatch {
+    background: var(--status-danger);
+}
+
+body.theme-light .threshold-swatch {
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.colours-open-btn {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #e0e0e0;
+    padding: 3px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.colours-open-btn:hover {
+    background: rgba(255, 255, 255, 0.14);
+}
+
+/* --- Colours page ----------------------------------------------------- */
+
+.colours-rows {
+    justify-content: flex-start;
+    gap: 4px;
+}
+
+.colours-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    color: #505060;
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin-top: 6px;
+}
+
+.colours-heading:first-child {
+    margin-top: 0;
+}
+
+/* margin rather than the parent's flex gap: the heading's own label is a bare
+   text node, and relying on gap to separate an anonymous flex item from a real
+   one is fragile. This spaces correctly whatever the parent's display is. */
+.colours-heading-hint {
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 400;
+    color: #45455a;
+    margin-left: 8px;
+}
+
+.colour-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 18px;
+}
+
+.colour-row-label {
+    color: #c0c0c0;
+    font-size: 11px;
+    width: 104px;
+    flex-shrink: 0;
+}
+
+.colour-row-hint {
+    color: #6a6a80;
+    font-size: 10px;
+}
+
+/* Placeholder keeping the Monthly Spend row's columns aligned with the rows
+   above it — that row has a bar but no countdown ring. */
+.colour-slot-empty {
+    visibility: hidden;
+}
+
+/* Live [base][75%][90%] strip: the only honest way to show Lighter/Darker,
+   which derive a different pair for every row. Filled by app.js. */
+.colour-preview {
+    display: inline-flex;
+    gap: 3px;
+}
+
+.colour-preview span {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+body.theme-light .colour-preview span {
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+}
+
+.radio-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: #c0c0c0;
+    font-size: 11px;
+    cursor: pointer;
+}
+
+.radio-label input[type="radio"] {
+    accent-color: #8b5cf6;
+    cursor: pointer;
+    margin: 0;
+}
+
+/* Rows that don't apply to the selected mode stay visible but inert, so the
+   panel doesn't reflow as the mode changes. */
+.colour-row.is-disabled {
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+.colour-reset-link {
     color: #8b5cf6;
     font-size: 11px;
     cursor: pointer;
     text-decoration: none;
+    margin-top: 4px;
 }
 
-.color-reset-link:hover {
+.colour-reset-link:hover {
     text-decoration: underline;
 }
 
@@ -1686,23 +1852,28 @@ body.theme-light .compact-expand-arrow {
     overflow: hidden;
 }
 
+/* Compact bars track the same row colors as their expanded counterparts, so
+   one setting per row covers both views. */
 .compact-bar-fill {
     height: 100%;
-    background: linear-gradient(90deg, #8b5cf6 0%, #a78bfa 100%);
+    background: linear-gradient(90deg, var(--row-session) 0%, var(--row-session-light) 100%);
     border-radius: 4px;
     transition: width 0.6s ease;
 }
 
 .compact-bar-fill.weekly {
-    background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%);
+    background: linear-gradient(90deg, var(--row-weekly) 0%, var(--row-weekly-light) 100%);
 }
 
 .compact-bar-fill.fable {
-    background: linear-gradient(90deg, #d946ef 0%, #e879f9 100%);
+    background: linear-gradient(90deg, var(--row-fable) 0%, var(--row-fable-light) 100%);
 }
 
+/* Was #1D9E75 -> #5DCAA5 here while the expanded Monthly Spend bar used
+   #10b981 -> #34d399: the same row in two shades of green. Unified onto the
+   expanded row's color so a single Monthly Spend setting drives both. */
 .compact-bar-fill.spend {
-    background: linear-gradient(90deg, #1D9E75 0%, #5DCAA5 100%);
+    background: linear-gradient(90deg, var(--row-spend) 0%, var(--row-spend-light) 100%);
 }
 
 .compact-bar-fill.warning {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -56,9 +56,9 @@
     --row-fable: #d946ef;
     --row-fable-light: #e879f9;
     --row-fable-glow: rgba(217, 70, 239, 0.3);
-    --row-spend: #10b981;
-    --row-spend-light: #34d399;
-    --row-spend-glow: rgba(16, 185, 129, 0.3);
+    --row-spend: #bc1010;
+    --row-spend-light: #f21717;
+    --row-spend-glow: rgba(188, 16, 16, 0.3);
 
     --ring-session: #8b5cf6;
     --ring-weekly: #3b82f6;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1194,11 +1194,15 @@ body.theme-light .threshold-swatch {
     gap: 4px;
 }
 
+/* Deliberately lighter than .col-header's #505060, which these headings used
+   to borrow: that value sits at roughly 1.9:1 against this panel and was hard
+   to read. #8a8aa0 is about 4.6:1. .col-header itself is left alone — the main
+   widget's column headers are unchanged. */
 .colours-heading {
     display: flex;
     align-items: baseline;
     gap: 8px;
-    color: #505060;
+    color: #8a8aa0;
     font-size: 9px;
     font-weight: 600;
     text-transform: uppercase;
@@ -1210,29 +1214,47 @@ body.theme-light .threshold-swatch {
     margin-top: 0;
 }
 
-/* margin rather than the parent's flex gap: the heading's own label is a bare
-   text node, and relying on gap to separate an anonymous flex item from a real
-   one is fragile. This spaces correctly whatever the parent's display is. */
-.colours-heading-hint {
-    text-transform: none;
-    letter-spacing: 0;
-    font-weight: 400;
-    color: #45455a;
-    margin-left: 8px;
+/* One grid shared by the column heads and every row, so a head sits directly
+   above the swatches it names. Separate columns rather than a flex gap is also
+   what keeps the two swatches apart instead of bunched: each sits at the start
+   of its own 52px column. */
+.colour-row {
+    display: grid;
+    grid-template-columns: 116px 52px 52px 1fr;
+    align-items: center;
+    gap: 10px;
+    min-height: 18px;
 }
 
-.colour-row {
+/* Rows whose controls are wider than a swatch column — the mode radios, the
+   percentage fields — keep only the label column and flex the rest, so the
+   left edge still lines up down the whole page. */
+.colour-row--wide {
+    grid-template-columns: 116px 1fr;
+}
+
+.colour-row-controls {
     display: flex;
     align-items: center;
     gap: 8px;
-    min-height: 18px;
+}
+
+.colour-col-head {
+    color: #70708a;
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
+}
+
+.colour-row-heads {
+    min-height: 12px;
 }
 
 .colour-row-label {
     color: #c0c0c0;
     font-size: 11px;
-    width: 104px;
-    flex-shrink: 0;
 }
 
 .colour-row-hint {
@@ -1286,7 +1308,11 @@ body.theme-light .colour-preview span {
     pointer-events: none;
 }
 
+/* Spans the whole grid: as the first child of its row it would otherwise land
+   in the 116px label column and wrap onto two lines. */
 .colour-reset-link {
+    grid-column: 1 / -1;
+    justify-self: start;
     color: #8b5cf6;
     font-size: 11px;
     cursor: pointer;
@@ -1593,12 +1619,15 @@ body.theme-light .colour-row-hint {
     color: #606078;
 }
 
+/* The dark theme lightens these for contrast against a dark panel; on the pale
+   panel that would wash them out, so they stay dark here — the same value the
+   main widget's column headers use on both themes. */
 body.theme-light .colours-heading {
     color: #505060;
 }
 
-body.theme-light .colours-heading-hint {
-    color: #707088;
+body.theme-light .colour-col-head {
+    color: #606078;
 }
 
 body.theme-light .colours-open-btn {


### PR DESCRIPTION
Follows on from my discussion #100 (Update Request: Elapsed Colours), and from 2283975, which decoupled the Elapsed rings from the usage thresholds but left the replacement colours hardcoded.

### The argument

**A session coming to an end is a good thing, not a bad thing.** Your limit is about to refresh. Colouring that progression amber and then red frames a routine, welcome event as an alarm — and it does it in the same two colours the bars use for *"you are nearly out of quota"*, so one palette ends up carrying two opposite meanings. In my opinion red/amber is simply a misplaced concept for a countdown to a reset.

2283975 already accepted half of this by decoupling the two, which I appreciated. This PR finishes the thought: instead of picking different fixed colours to argue about, each ring stages through **lighter shades of its own colour**. The hue still tells you which row the ring belongs to, the brightness tells you how far through the window you are, and severity language is left to the bars, where it actually means something.

### What this does

**1. Every row colour is configurable.** Seven new settings — bar and ring separately for Current Session, Weekly Limit and Fable Weekly, plus the Monthly Spend bar. All identity colours move into CSS custom properties, so `styles.css` keeps one source of truth and the renderer writes the variables from settings.

**2. Three modes for the Elapsed rings** (rings only — the bars keep their own warn/danger colours):

- `custom` — the two picked colours, one pair for every ring; today's behaviour
- `lighter` — each ring stages through lighter shades of its own colour
- `darker` — the same, toward black

`hslShift()` holds hue and saturation and moves lightness a percentage of the distance *remaining* to white or black, so a colour already near the target barely moves and one far away moves a lot — which is what keeps the two stages apart whatever the base colour is. Both distances are configurable.

**3. A Colours page**, reached from Settings. Twelve rows of swatches wouldn't fit the fixed-height, non-scrolling settings panel, so they live behind a button; the two threshold pickers moved there too, and Settings keeps the "Warn at" numbers with a read-only dot showing which colour each state paints.

Each row shows a live `[base][75%][90%]` preview strip. That's the only honest way to display Lighter/Darker: because the derivation is per-row, there is no single derived colour a shared swatch could show.

### The default change — easy to drop

**The last commit is the only one that changes what existing users see, and it's deliberately separate so you can drop it and take just the feature.** It sets `elapsedColorMode` to `lighter` at 20%/40%, and turns the Monthly Spend bar red (it was the one row wearing green while measuring money leaving).

That commit is where my argument above actually bites, so I'd rather make the case than ship it switched off — but it's your call, and `custom` mode preserves today's exact appearance if you'd prefer the defaults untouched. Dropping that one commit leaves the feature fully intact.

### Screenshots

The Colours page, dark and light:

![Colours page, dark theme](https://raw.githubusercontent.com/KickTechnic/claude-usage-widget/pr-assets/docs/pr-assets/colours-page-dark.png)

![Colours page, light theme](https://raw.githubusercontent.com/KickTechnic/claude-usage-widget/pr-assets/docs/pr-assets/colours-page-light.png)

### Implementation notes

Per-row derivation without touching the `.timer-progress` rules: custom properties inherit, so lighter/darker write `--elapsed-warn` / `--elapsed-soon` onto each **row** element and each row's ring picks up its own pair, while custom mode writes one pair on `:root` and clears the overrides. Extra rows are rebuilt on every fetch, so `buildExtraRows()` re-applies them at the end, otherwise a derived ring reverts to the global pair on the next refresh.

`DEFAULT_LIGHT_STOPS` maps each default colour to the gradient partner the app already used (`#8b5cf6` → `#a78bfa`, and so on). Those pairs are hand-picked Tailwind steps that shift hue and saturation as well as lightness, so no formula reproduces them — an HSL lighten renders `#f59e0b` as `#f7b546`, not `#fbbf24`, which would have quietly restyled every install. User-picked colours fall through to the formula.

Tray badges follow the configured row colours too: `getBackgroundColor()` took warn/danger and hardcoded purple and blue for the below-threshold case.

One default shifts as a side effect: the compact Monthly Spend bar was `#1D9E75` while the expanded one was `#10b981` — the same row in two greens. A single setting now drives both.

### Testing

Windows 11, run from source and as a packaged build, against a live account.

- **Defaults unchanged** by the feature commits — computed gradients still `rgb(139,92,246) → rgb(167,139,250)` etc., byte-identical to before
- **Derivation is genuinely per-row**: in Lighter at 75% elapsed the three rings are `#d8c8fc` / `#bcd4fc` / `#f2c0fa` — three different colours; in Custom all three are identical. Same for Darker.
- Mode switching enables/disables the right controls; changing a percentage moves the derived colour; a custom ring colour feeds its own derivation while leaving other rows alone
- Colours, mode and percentages survive a restart and apply before first paint
- Reset restores every colour plus the mode and both percentages
- Colours page fits with no clipping, and is legible in both themes
- Verified the new defaults against a throwaway `--profile` with nothing stored, which is what a new install sees

### Notes

Built on #112, because the Fable row's colours need a `#fableSection` to attach to. This diff will shrink to just the colour work once that merges. Happy to rebase, split further, or drop the defaults commit — whatever's easiest to review.
