### PR TITLE
Issue Fix: retry on transient 429, distinguish RateLimited from SessionExpired, jitter refresh interval

### DIFF
--- a/main.js
+++ b/main.js
@@ -1501,39 +1501,78 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
   // Fetch endpoints sequentially using a single reused BrowserWindow.
   // This reduces memory overhead compared to creating 3 separate windows.
   // Usage is always required; overage and prepaid are conditional based on UI state.
+  //
+  // Retry policy: transient rate-limit responses (HTTP 429) are retried with
+  // exponential backoff (1s, 5s, 30s, each ±25% jitter) up to 3 attempts.
+  // Session-bound blocks (Cloudflare challenge, expired cookies, unexpected
+  // HTML) are NOT retried — they would just waste time and rate-limit budget.
+  const MAX_RETRIES = 3;
+  const BASE_BACKOFF_MS = [1000, 5000, 30000];
   let usageResult, overageResult, prepaidResult;
-  
-  try {
-    const results = await fetchMultipleViaWindow(urls);
-    
-    // Always have usage result (first in array)
-    usageResult = { status: 'fulfilled', value: results[0] };
-    
-    // Conditionally map overage/prepaid results
-    if (shouldFetchExtended) {
-      overageResult = { status: 'fulfilled', value: results[1] };
-      prepaidResult = { status: 'fulfilled', value: results[2] };
-    } else {
-      // Mark as skipped (not an error, just not fetched)
-      overageResult = { status: 'skipped', reason: 'UI panel not visible' };
-      prepaidResult = { status: 'skipped', reason: 'UI panel not visible' };
+
+  let attempt = 0;
+  let lastError = null;
+  while (attempt <= MAX_RETRIES) {
+    try {
+      const results = await fetchMultipleViaWindow(urls);
+
+      // Always have usage result (first in array)
+      usageResult = { status: 'fulfilled', value: results[0] };
+
+      // Conditionally map overage/prepaid results
+      if (shouldFetchExtended) {
+        overageResult = { status: 'fulfilled', value: results[1] };
+        prepaidResult = { status: 'fulfilled', value: results[2] };
+      } else {
+        // Mark as skipped (not an error, just not fetched)
+        overageResult = { status: 'skipped', reason: 'UI panel not visible' };
+        prepaidResult = { status: 'skipped', reason: 'UI panel not visible' };
+      }
+      lastError = null;
+      break;
+    } catch (error) {
+      lastError = error;
+      const isRateLimit = error.message.startsWith('RateLimited');
+      const isSessionBound = error.message.startsWith('CloudflareBlocked')
+        || error.message.startsWith('CloudflareChallenge')
+        || error.message.startsWith('UnexpectedHTML')
+        || error.message.startsWith('Unauthorized')
+        || error.message.startsWith('LoadFailed');
+
+      // Session-bound errors: do not retry — propagate immediately so the
+      // caller can prompt re-login. Rate-limited: retry with backoff.
+      if (!isRateLimit || isSessionBound) {
+        usageResult = { status: 'rejected', reason: error };
+        overageResult = { status: 'rejected', reason: error };
+        prepaidResult = { status: 'rejected', reason: error };
+        break;
+      }
+
+      if (attempt >= MAX_RETRIES) {
+        debugLog(`[Retry] Exhausted ${MAX_RETRIES} retries on rate-limit`);
+        usageResult = { status: 'rejected', reason: error };
+        overageResult = { status: 'rejected', reason: error };
+        prepaidResult = { status: 'rejected', reason: error };
+        break;
+      }
+
+      const base = BASE_BACKOFF_MS[attempt];
+      const jitter = base * (0.75 + Math.random() * 0.5); // ±25%
+      debugLog(`[Retry] Rate-limited (attempt ${attempt + 1}/${MAX_RETRIES}); sleeping ${Math.round(jitter)}ms`);
+      await new Promise((r) => setTimeout(r, jitter));
+      attempt++;
     }
-  } catch (error) {
-    // If any fetch fails, determine which one and set appropriate result statuses
-    // For now, if the batch fails, treat usage as failed (required endpoint)
-    usageResult = { status: 'rejected', reason: error };
-    overageResult = { status: 'rejected', reason: error };
-    prepaidResult = { status: 'rejected', reason: error };
   }
 
   // Usage endpoint is mandatory
   if (usageResult.status === 'rejected') {
     const error = usageResult.reason;
     debugLog('API request failed:', error.message);
-    const isBlocked = error.message.startsWith('CloudflareBlocked')
+    const isSessionExpired = error.message.startsWith('CloudflareBlocked')
       || error.message.startsWith('CloudflareChallenge')
-      || error.message.startsWith('UnexpectedHTML');
-    if (isBlocked) {
+      || error.message.startsWith('UnexpectedHTML')
+      || error.message.startsWith('Unauthorized');
+    if (isSessionExpired) {
       store.delete('sessionKey');
       store.delete('organizationId');
       if (mainWindow) {
@@ -1541,6 +1580,10 @@ ipcMain.handle('fetch-usage-data', async (event, options = {}) => {
       }
       throw new Error('SessionExpired');
     }
+    // RateLimited that exhausted retries — keep the session intact so the
+    // user is not forced to re-login for a transient upstream throttle.
+    // The error message starts with 'RateLimited:' so the renderer can
+    // surface a 'temporarily unavailable' indicator.
     throw error;
   }
 

--- a/src/fetch-via-window.js
+++ b/src/fetch-via-window.js
@@ -18,6 +18,11 @@ const { BrowserWindow } = require('electron');
  * Known error signatures returned when Claude.ai blocks or changes behaviour.
  * If the extracted body matches one of these patterns we throw a specific error
  * so callers can react (e.g. prompt re-login).
+ *
+ * Note: 429 rate-limit responses are classified separately as `RateLimited`
+ * (transient — caller may retry without invalidating the session). The
+ * patterns below identify *blocking* conditions (session-bound), where
+ * retrying with the same cookie will not help.
  */
 const BLOCKED_SIGNATURES = [
   { pattern: 'Just a moment', error: 'CloudflareBlocked' },
@@ -26,11 +31,33 @@ const BLOCKED_SIGNATURES = [
 ];
 
 /**
+ * Transient rate-limit signatures — these do NOT indicate an invalid session
+ * and are safe to retry with backoff. Checked *before* BLOCKED_SIGNATURES
+ * so that a Cloudflare-served 429 page is classified as rate-limit, not block.
+ */
+const RATE_LIMIT_SIGNATURES = [
+  'rate limit',
+  'too many requests',
+  '"status":429',
+  '"status": 429',
+];
+
+/**
  * Parse and validate response body text
  * @param {string} bodyText - Raw body text from the page * @returns {Object} Parsed JSON data
  * @throws {Error} If blocked signatures detected or JSON parsing fails
  */
 function parseResponseBody(bodyText) {
+  // Classify rate-limit responses separately from session-bound blocks.
+  // Callers can retry RateLimited with exponential backoff without
+  // invalidating sessionKey/organizationId.
+  const lower = bodyText.toLowerCase();
+  for (const sig of RATE_LIMIT_SIGNATURES) {
+    if (lower.includes(sig)) {
+      throw new Error(`RateLimited: ${bodyText.substring(0, 200)}`);
+    }
+  }
+
   // Detect known block/failure signatures before attempting JSON parse.
   // This provides explicit errors when Claude.ai modifies their API or CSP.
   for (const sig of BLOCKED_SIGNATURES) {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1,6 +1,7 @@
 // Application state
 let credentials = null;
 let updateInterval = null;
+let _autoUpdateStopped = true;  // when true, the next scheduleAutoUpdate tick won't re-arm
 let countdownInterval = null;
 let latestUsageData = null;
 let isExpanded = false;
@@ -1442,20 +1443,42 @@ function showMainContent() {
 }
 
 // Auto-update management
-function startAutoUpdate() {
+// Jitter cap: ±25% of the configured interval, so a herd of widget instances
+// does not all hit Claude.ai at exactly the same tick. Applied to the *delay*
+// before each fetch, not the timer period itself, so a slow fetch does not
+// cause a missed tick.
+const JITTER_FRACTION = 0.25;
+
+function scheduleAutoUpdate() {
     stopAutoUpdate();
     const settings = window._cachedSettings || {};
     const intervalSecs = parseInt(settings.refreshInterval) || 300;
-    updateInterval = setInterval(async () => {
+    const baseMs = intervalSecs * 1000;
+    const jitter = baseMs * JITTER_FRACTION * (Math.random() * 2 - 1);
+    const delay = Math.max(1000, Math.round(baseMs + jitter));
+    updateInterval = setTimeout(async () => {
         if (elements.refreshBtn) elements.refreshBtn.classList.add('spinning');
-        await fetchUsageData();
-        if (elements.refreshBtn) elements.refreshBtn.classList.remove('spinning');
-    }, intervalSecs * 1000);
+        try {
+            await fetchUsageData();
+        } finally {
+            if (elements.refreshBtn) elements.refreshBtn.classList.remove('spinning');
+            // Schedule the next tick only after this fetch completes (success
+            // or fail), so an in-flight 429 retry never overlaps with the next
+            // auto-refresh.
+            if (!_autoUpdateStopped) scheduleAutoUpdate();
+        }
+    }, delay);
+}
+
+function startAutoUpdate() {
+    _autoUpdateStopped = false;
+    scheduleAutoUpdate();
 }
 
 function stopAutoUpdate() {
+    _autoUpdateStopped = true;
     if (updateInterval) {
-        clearInterval(updateInterval);
+        clearTimeout(updateInterval);
         updateInterval = null;
     }
 }


### PR DESCRIPTION
## Summary

Three related reliability fixes for the widget on long-running connections / shared upstream IPs:

1. **Retry with exponential backoff on transient 429s** (1s to 5s to 30s, each plus/minus 25% jitter, max 3 attempts). Before this PR, a single 429 from Claude.ai's edge was treated identically to a Cloudflare challenge or an expired cookie — the widget deleted sessionKey and organizationId, fired session-expired to the renderer, and forced the user through a manual re-login flow that itself involves a Cloudflare wall. The widget should be a passive observer; getting booted because the user closed the lid on their laptop for a minute is hostile.

2. **Distinguish RateLimited from SessionExpired** in error classification. A new error prefix 'RateLimited:' is thrown from fetch-via-window.js BEFORE the Cloudflare/UnexpectedHTML/Unauthorized matchers. Only session-bound errors (the latter group) invalidate the stored cookie and trigger re-login. A RateLimited that exhausts its retry budget now bubbles up as 'RateLimited: ...' so the renderer can render a 'temporarily unavailable' state instead of the login screen. Also widened the SessionExpired matcher to include 'Unauthorized' (401) — Claude.ai returns 401 cleanly on a bad cookie, and treating that as transient would loop forever.

3. **Jitter on the auto-refresh interval** (plus/minus 25% of the configured interval). Replaced setInterval with a recursive setTimeout whose next delay is recomputed each cycle. Two reasons: (a) a herd of widget instances stops polling on the same tick, which is exactly what triggers upstream rate limits in the first place; (b) the next tick is scheduled AFTER the current fetch completes, so an in-flight 429 retry chain can never overlap with the next auto-refresh.

## Why these three together

They are really one issue — 'what happens when Claude.ai says no for a moment?' — split across the three layers where it can be answered. Without (1), retrying on a transient throttle does not help if you still nuke the session on the first failed attempt. Without (2), every retry counts as a session expiry. Without (3), the next auto-refresh will trigger another 429 the moment your jitter-free timer fires during a Claude.ai cooldown. Each one is independently small; together they keep the widget showing the last good value for hours of upstream throttling instead of bouncing the user to the login screen.

## Files

- src/fetch-via-window.js — new RATE_LIMIT_SIGNATURES list; parseResponseBody classifies RateLimited before block signatures.
- main.js — fetch-usage-data IPC handler now wraps fetchMultipleViaWindow in a retry loop (MAX_RETRIES=3, BASE_BACKOFF_MS=[1000, 5000, 30000], plus/minus 25% jitter) and only triggers session-expired flow on session-bound error classes.
- src/renderer/app.js — setInterval replaced with recursive setTimeout with jitter (scheduleAutoUpdate); _autoUpdateStopped guard prevents re-arming during stopAutoUpdate.

## Testing notes

I do not have a Windows/macOS box handy to run the Electron build itself, but the logic is plain JavaScript:

parseResponseBody('{"status":429,"error":"rate limit"}')
// throws 'RateLimited: ...'  (new)

parseResponseBody('Just a moment...')
// throws 'CloudflareBlocked: ...'  (unchanged behaviour)

parseResponseBody('Enable JavaScript and cookies to continue')
// throws 'CloudflareChallenge: ...'  (unchanged behaviour)

The retry loop's MAX_RETRIES and BASE_BACKOFF_MS are locals at the top of fetch-usage-data so they are trivial to tune without grep hunting.

## Notes for maintainers

I deliberately did NOT touch STAGED_CHANGES.md — your contributor docs say changes go there at merge time, and this is still a draft PR. Happy to add an entry there in a follow-up if you would like, with whatever wording you prefer.

I targeted develop since CONTRIBUTING.md says PRs flow through feature branches into develop (and main is the v1.7.5 release snapshot).