### PR TITLE
Add a custom-skins system: 10 presets, token contract, and validated custom import (+AI!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ developerID_application.cer
 
 # Temp commit message files
 commit_msg.txt
+
+# Generated skin bundle — regenerated from src/renderer/skins/presets/*.json
+# and CREATING_A_SKIN.md by scripts/validate-skins.js before every entry
+# point (predev/prestart/prebuild*), so it never needs to be committed and
+# would only add merge-conflict-prone diff noise if it were.
+src/renderer/skins/presets/presets.generated.js

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const https = require('https');
 const Store = require('electron-store');
 const { fetchViaWindow, fetchMultipleViaWindow } = require('./src/fetch-via-window');
 const { normalizeUsageLimits } = require('./src/normalize-usage-limits');
+const { validateSkin } = require('./src/skin-validator');
 
 const GITHUB_OWNER = 'SlavomirDurej';
 const GITHUB_REPO = 'claude-usage-widget';
@@ -1152,7 +1153,9 @@ ipcMain.handle('get-settings', () => {
     graphVisible: store.get('settings.graphVisible', false),
     expandedOpen: store.get('settings.expandedOpen', false),
     compactSpendOpen: store.get('settings.compactSpendOpen', false),
-    showTrayStats: store.get('settings.showTrayStats', false)
+    showTrayStats: store.get('settings.showTrayStats', false),
+    skin: store.get('settings.skin', 'none'),
+    glassLevel: store.get('settings.glassLevel', 'medium')
   };
 });
 
@@ -1179,6 +1182,8 @@ ipcMain.handle('save-settings', (event, settings) => {
     store.set('settings.compactSpendOpen', settings.compactSpendOpen);
   }
   store.set('settings.showTrayStats', settings.showTrayStats);
+  store.set('settings.skin', settings.skin || 'none');
+  store.set('settings.glassLevel', settings.glassLevel || 'medium');
 
   const isPortable = process.platform === 'win32' && !!process.env.PORTABLE_EXECUTABLE_FILE;
 
@@ -1217,6 +1222,80 @@ ipcMain.handle('save-settings', (event, settings) => {
   }
 
   return true;
+});
+
+// Custom skins — user-imported (pasted or AI-generated) token-only skins.
+// Always re-validated here on read, not just on import, so a hand-edited
+// config.json can't smuggle in something the validator would have rejected.
+ipcMain.handle('get-custom-skins', () => {
+  const stored = store.get('customSkins', []);
+  return stored.filter(s => validateSkin(s, { context: 'custom' }).valid);
+});
+
+// Built-in preset ids, read once from the source-of-truth JSON files (not
+// the renderer bundle) so a custom skin can never shadow a built-in — see
+// src/renderer/skins/presets/*.json.
+const BUILTIN_SKIN_IDS = new Set(
+  fs.readdirSync(path.join(__dirname, 'src', 'renderer', 'skins', 'presets'))
+    .filter(f => f.endsWith('.json') && f !== 'presets.generated.js')
+    .map(f => {
+      try {
+        return JSON.parse(fs.readFileSync(path.join(__dirname, 'src', 'renderer', 'skins', 'presets', f), 'utf-8')).id;
+      } catch (e) {
+        return null;
+      }
+    })
+    .filter(Boolean)
+);
+BUILTIN_SKIN_IDS.add('none');
+
+const MAX_IMPORT_SKIN_JSON_LENGTH = 50 * 1024;
+
+ipcMain.handle('import-custom-skin', (event, rawSkin) => {
+  let skin = rawSkin;
+  if (typeof rawSkin === 'string') {
+    if (rawSkin.length > MAX_IMPORT_SKIN_JSON_LENGTH) {
+      return { success: false, error: 'Skin JSON is too large' };
+    }
+    try {
+      skin = JSON.parse(rawSkin);
+    } catch (e) {
+      return { success: false, error: 'Not valid JSON: ' + e.message };
+    }
+  }
+
+  const result = validateSkin(skin, { context: 'custom' });
+  if (!result.valid) {
+    return { success: false, error: result.errors.join('; ') };
+  }
+
+  if (BUILTIN_SKIN_IDS.has(skin.id)) {
+    return { success: false, error: `"${skin.id}" is a built-in skin id and can't be reused for a custom skin` };
+  }
+
+  // Strip to exactly the allowed shape — never persist extra fields even if
+  // the validator's allow-list is ever loosened later.
+  const clean = {
+    id: skin.id,
+    name: skin.name,
+    tokens: { ...skin.tokens },
+  };
+  if (skin.author) clean.author = skin.author;
+  if (skin.description) clean.description = skin.description;
+
+  const existing = store.get('customSkins', []);
+  if (existing.some(s => s.id === clean.id)) {
+    return { success: false, error: `A custom skin with id "${clean.id}" already exists` };
+  }
+  store.set('customSkins', [...existing, clean]);
+  return { success: true, skin: clean };
+});
+
+ipcMain.handle('delete-custom-skin', (event, id) => {
+  if (typeof id !== 'string' || !id) return { success: false };
+  const existing = store.get('customSkins', []);
+  store.set('customSkins', existing.filter(s => s.id !== id));
+  return { success: true };
 });
 
 // Open a visible BrowserWindow for the user to log in to Claude.ai.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,19 @@
   "description": "Desktop widget for Claude.ai usage monitoring",
   "main": "main.js",
   "scripts": {
+    "prestart": "npm run validate-skins",
     "start": "electron .",
+    "prebuild": "npm run validate-skins",
     "build": "electron-builder",
+    "prebuild:win": "npm run validate-skins",
     "build:win": "electron-builder --win",
+    "predev": "npm run validate-skins",
     "dev": "cross-env NODE_ENV=development electron .",
+    "prebuild:mac": "npm run validate-skins",
     "build:mac": "electron-builder --mac",
-    "build:linux": "electron-builder --linux"
+    "prebuild:linux": "npm run validate-skins",
+    "build:linux": "electron-builder --linux",
+    "validate-skins": "node scripts/validate-skins.js"
   },
   "keywords": [
     "claude",

--- a/preload.js
+++ b/preload.js
@@ -71,5 +71,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   showNotification: (title, body) => ipcRenderer.send('show-notification', { title, body }),
 
   // Compact mode
-  setCompactMode: (compact) => ipcRenderer.send('set-compact-mode', compact)
+  setCompactMode: (compact) => ipcRenderer.send('set-compact-mode', compact),
+
+  // Custom skins
+  getCustomSkins: () => ipcRenderer.invoke('get-custom-skins'),
+  importCustomSkin: (skin) => ipcRenderer.invoke('import-custom-skin', skin),
+  deleteCustomSkin: (id) => ipcRenderer.invoke('delete-custom-skin', id)
 });

--- a/scripts/validate-skins.js
+++ b/scripts/validate-skins.js
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+// Validates every built-in preset in src/renderer/skins/presets/*.json against
+// the shared skin-validator, runs negative and adversarial (injection/bypass/
+// prototype-pollution/ReDoS) tests against the validator itself (so a broken
+// validator can't silently pass everything), then regenerates
+// src/renderer/skins/presets/presets.generated.js — the file the renderer
+// actually loads (the app's CSP blocks fetch/XHR, so presets must ship as a
+// statically-<script>-included JS array, not fetched JSON at runtime).
+//
+// Run manually with `npm run validate-skins`; also runs automatically before
+// `npm run dev` / `npm start` (see package.json) so the generated file can
+// never go stale relative to the source JSON.
+
+const fs = require('fs');
+const path = require('path');
+const { validateSkin, KNOWN_TOKENS } = require('../src/skin-validator');
+
+const PRESETS_DIR = path.join(__dirname, '..', 'src', 'renderer', 'skins', 'presets');
+const OUTPUT_FILE = path.join(PRESETS_DIR, 'presets.generated.js');
+const PROMPT_DOC_FILE = path.join(__dirname, '..', 'src', 'renderer', 'skins', 'CREATING_A_SKIN.md');
+
+let failures = 0;
+
+function fail(msg) {
+  console.error(`✗ ${msg}`);
+  failures++;
+}
+function pass(msg) {
+  console.log(`✓ ${msg}`);
+}
+
+// ── 1. Negative tests against the validator itself ─────────────────────────
+function runNegativeTests() {
+  const cases = [
+    {
+      name: 'rejects a skin missing a required token',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-text': '#fff' } },
+      opts: { context: 'custom' },
+    },
+    {
+      name: 'rejects a url() injection attempt in a token value',
+      skin: {
+        id: 'x', name: 'X',
+        tokens: { '--skin-bg': 'url(https://evil.example/track.png)', '--skin-text': '#fff', '--skin-accent': '#fff' },
+      },
+      opts: { context: 'custom' },
+    },
+    {
+      name: 'rejects an unknown top-level field',
+      skin: {
+        id: 'x', name: 'X', evil: true,
+        tokens: { '--skin-bg': '#000', '--skin-text': '#fff', '--skin-accent': '#fff' },
+      },
+      opts: { context: 'custom' },
+    },
+    {
+      name: 'rejects a custom skin that includes "advanced"',
+      skin: {
+        id: 'x', name: 'X', advanced: 'liquid.css',
+        tokens: { '--skin-bg': '#000', '--skin-text': '#fff', '--skin-accent': '#fff' },
+      },
+      opts: { context: 'custom' },
+    },
+    {
+      name: 'rejects an unknown token name',
+      skin: {
+        id: 'x', name: 'X',
+        tokens: { '--skin-bg': '#000', '--skin-text': '#fff', '--skin-accent': '#fff', '--skin-totally-made-up': '#fff' },
+      },
+      opts: { context: 'custom' },
+    },
+    {
+      name: 'accepts a minimal well-formed custom skin',
+      skin: {
+        id: 'ok-skin', name: 'OK Skin',
+        tokens: { '--skin-bg': '#101018', '--skin-text': '#eee', '--skin-accent': '#8b5cf6' },
+      },
+      opts: { context: 'custom' },
+      expectValid: true,
+    },
+  ];
+
+  for (const c of cases) {
+    const result = validateSkin(c.skin, c.opts);
+    const shouldBeValid = !!c.expectValid;
+    if (result.valid === shouldBeValid) {
+      pass(`validator: ${c.name}`);
+    } else {
+      fail(`validator: ${c.name} — expected valid=${shouldBeValid}, got valid=${result.valid} (${result.errors.join('; ')})`);
+    }
+  }
+}
+
+// ── 1b. Adversarial tests — real injection/bypass payloads the validator
+//       must reject. This is the checked-in record of the manual red-team
+//       pass run against this feature before it shipped (case-variant/
+//       escaped/comment-split url() bypasses, prototype pollution, malformed
+//       shapes, id/advanced-field abuse, length/format boundaries, and a
+//       ReDoS timing guard on the regexes) — committed so it runs on every
+//       `npm run validate-skins` / dev / build, not just once in review. ────
+function runAdversarialTests() {
+  const validTokens = () => ({ '--skin-text': '#fff', '--skin-accent': '#f00' });
+
+  const cases = [
+    // url()/CSS-function injection bypass attempts
+    {
+      name: 'rejects case-variant url() ("URL(...)")',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': 'URL(https://evil.example/x.png)', ...validTokens() } },
+    },
+    {
+      name: 'rejects a data: URI payload',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': 'url(data:text/html,<script>alert(1)</script>)', ...validTokens() } },
+    },
+    {
+      name: 'rejects a javascript: URI payload',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': 'javascript:alert(1)', ...validTokens() } },
+    },
+    {
+      name: 'rejects expression() (legacy IE CSS injection)',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': 'expression(alert(1))', ...validTokens() } },
+    },
+    {
+      name: 'rejects an @import payload',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': '@import url(evil.css)', ...validTokens() } },
+    },
+    {
+      name: 'rejects an angle-bracket/markup payload',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': '<img src=x onerror=alert(1)>', ...validTokens() } },
+    },
+    {
+      name: 'rejects a backslash CSS-escape bypass attempt ("\\75rl(...)")',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': '\\75rl(evil)', ...validTokens() } },
+    },
+    {
+      name: 'rejects a semicolon/brace declaration-breakout attempt',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': 'red; } body { background: url(evil)', ...validTokens() } },
+    },
+    {
+      name: 'rejects a comment-split url() bypass ("ur/**/l(...)")',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': 'ur/**/l(evil)', ...validTokens() } },
+    },
+    {
+      name: 'rejects calc()/em on --skin-radius (only plain px/% lengths allowed)',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-radius': 'calc(100% - 4px)', ...validTokens() } },
+    },
+
+    // Structural / prototype-pollution attempts. Built via JSON.parse, not a
+    // JS object literal — a literal `{ __proto__: {...} }` sets the actual
+    // prototype instead of creating an own enumerable "__proto__" property,
+    // which would make these tests pass for the wrong reason.
+    {
+      name: 'rejects a "__proto__" top-level field',
+      skin: JSON.parse('{"id":"x","name":"X","__proto__":{"polluted":true},"tokens":{"--skin-text":"#fff","--skin-accent":"#f00"}}'),
+    },
+    {
+      name: 'rejects a "__proto__" nested inside tokens',
+      skin: JSON.parse('{"id":"x","name":"X","tokens":{"__proto__":{"polluted":true},"--skin-text":"#fff","--skin-accent":"#f00"}}'),
+    },
+    { name: 'rejects a null skin', skin: null },
+    { name: 'rejects an array as the skin body', skin: ['not', 'an', 'object'] },
+    { name: 'rejects a bare string as the skin body', skin: 'just a string' },
+
+    // id / advanced-field abuse
+    {
+      name: 'rejects a path-traversal id',
+      skin: { id: '../../etc', name: 'X', tokens: validTokens() },
+    },
+    {
+      name: 'rejects a markup-shaped id',
+      skin: { id: 'x"><script>', name: 'X', tokens: validTokens() },
+    },
+    {
+      name: 'rejects "advanced" smuggled into a custom-context skin via path traversal',
+      skin: { id: 'x', name: 'X', advanced: '../../evil.css', tokens: validTokens() },
+    },
+    {
+      name: 'rejects a control character in name',
+      skin: { id: 'x', name: 'X\x00evil', tokens: validTokens() },
+    },
+
+    // Length/format boundaries
+    {
+      name: 'rejects a token value one char over the 300-char cap',
+      skin: { id: 'x', name: 'X', tokens: { '--skin-bg': '#'.padEnd(301, '0'), ...validTokens() } },
+    },
+    {
+      name: 'accepts a token value exactly at the 300-char cap',
+      skin: { id: 'ok-skin', name: 'X', tokens: { '--skin-bg': 'a'.repeat(300).replace(/^./, '#'), ...validTokens() } },
+      expectValid: true,
+    },
+  ];
+
+  for (const c of cases) {
+    const result = validateSkin(c.skin, { context: 'custom' });
+    const shouldBeValid = !!c.expectValid;
+    if (result.valid === shouldBeValid) {
+      pass(`adversarial: ${c.name}`);
+    } else {
+      fail(`adversarial: ${c.name} — expected valid=${shouldBeValid}, got valid=${result.valid} (${(result.errors || []).join('; ')})`);
+    }
+  }
+
+  // ReDoS guard: the validator's regexes must stay linear-time even against
+  // adversarial near-miss input, not just reject it eventually.
+  const nasty = 'a'.repeat(200000) + '!';
+  const start = Date.now();
+  validateSkin({ id: 'x', name: 'X', tokens: { '--skin-bg': nasty, ...validTokens() } }, { context: 'custom' });
+  const elapsed = Date.now() - start;
+  if (elapsed < 200) {
+    pass(`adversarial: validator stays fast on a 200k-char adversarial value (${elapsed}ms)`);
+  } else {
+    fail(`adversarial: validator took ${elapsed}ms on a 200k-char adversarial value — possible ReDoS regression`);
+  }
+}
+
+// ── 2. Validate every built-in preset JSON ──────────────────────────────────
+function loadAndValidatePresets() {
+  const files = fs.readdirSync(PRESETS_DIR).filter(f => f.endsWith('.json')).sort();
+  if (files.length === 0) {
+    fail(`no preset JSON files found in ${PRESETS_DIR}`);
+    return [];
+  }
+
+  const presets = [];
+  const seenIds = new Set();
+
+  for (const file of files) {
+    const full = path.join(PRESETS_DIR, file);
+    let skin;
+    try {
+      skin = JSON.parse(fs.readFileSync(full, 'utf8'));
+    } catch (e) {
+      fail(`${file}: invalid JSON (${e.message})`);
+      continue;
+    }
+
+    const result = validateSkin(skin, { context: 'builtin' });
+    if (!result.valid) {
+      fail(`${file}: ${result.errors.join('; ')}`);
+      continue;
+    }
+
+    if (skin.advanced) {
+      const cssPath = path.join(PRESETS_DIR, '..', skin.advanced);
+      if (!fs.existsSync(cssPath)) {
+        fail(`${file}: advanced references "${skin.advanced}", which does not exist at ${cssPath}`);
+        continue;
+      }
+    }
+
+    if (seenIds.has(skin.id)) {
+      fail(`${file}: duplicate skin id "${skin.id}"`);
+      continue;
+    }
+    seenIds.add(skin.id);
+
+    pass(`preset ${file}: valid ("${skin.name}", ${Object.keys(skin.tokens).length} tokens${skin.advanced ? `, advanced=${skin.advanced}` : ''})`);
+    presets.push(skin);
+  }
+
+  return presets;
+}
+
+// ── 3. Load the AI-generation prompt doc (single source of truth for the
+//      "Copy AI prompt" button — copying the whole file, not a regex-carved
+//      excerpt, so nothing drifts out of sync if the doc changes later).
+//      Optional: the custom-import feature (and this doc) is designed to be
+//      independently revertable from the core token/preset system — see
+//      src/renderer/skins/RATIONALE.md — so a missing file here just means
+//      that feature isn't present, not a broken build. ──────────────────────
+function loadPromptDoc() {
+  if (!fs.existsSync(PROMPT_DOC_FILE)) {
+    pass('CREATING_A_SKIN.md not present — skipping the Copy AI prompt bundle (custom-import feature not installed)');
+    return null;
+  }
+  const text = fs.readFileSync(PROMPT_DOC_FILE, 'utf8');
+  pass(`loaded CREATING_A_SKIN.md (${text.length} chars) for the Copy AI prompt button`);
+  return text;
+}
+
+// ── 4. Regenerate the CSP-safe, statically-included runtime file ───────────
+function writeGeneratedFile(presets, promptDoc) {
+  const banner = `// AUTO-GENERATED by scripts/validate-skins.js — do not edit by hand.
+// Source of truth: src/renderer/skins/presets/*.json and
+// src/renderer/skins/CREATING_A_SKIN.md.
+// Regenerate with \`npm run validate-skins\` (also runs automatically before
+// \`npm run dev\` / \`npm start\`). Shipped as a plain <script> include (not
+// fetched) because this app's CSP sets connect-src 'none'.
+`;
+  const body =
+    // Generated from skin-validator.js's KNOWN_TOKENS, not hand-copied, so
+    // skin-manager.js's allow-list can never drift out of sync with the
+    // validator's — see skin-manager.js's applySkin().
+    `window.SKIN_KNOWN_TOKENS = ${JSON.stringify(KNOWN_TOKENS)};\n` +
+    `window.SKIN_PRESETS = ${JSON.stringify(presets, null, 2)};\n` +
+    `window.SKIN_AI_PROMPT_DOC = ${JSON.stringify(promptDoc)};\n`;
+  fs.writeFileSync(OUTPUT_FILE, banner + body, 'utf8');
+  console.log(`\nWrote ${presets.length} preset(s) + the AI prompt doc to ${path.relative(process.cwd(), OUTPUT_FILE)}`);
+}
+
+runNegativeTests();
+runAdversarialTests();
+const presets = loadAndValidatePresets();
+const promptDoc = loadPromptDoc();
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed. Not regenerating presets.generated.js.`);
+  process.exit(1);
+}
+
+writeGeneratedFile(presets, promptDoc);
+console.log('All skin checks passed.');

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -89,6 +89,18 @@ const elements = {
     warnThreshold: document.getElementById('warnThreshold'),
     dangerThreshold: document.getElementById('dangerThreshold'),
     themeBtns: document.querySelectorAll('.theme-btn'),
+    skinSelector: document.getElementById('skinSelector'),
+    skinBrowseAllBtn: document.getElementById('skinBrowseAllBtn'),
+    skinPopupOverlay: document.getElementById('skinPopupOverlay'),
+    skinPopupCloseBtn: document.getElementById('skinPopupCloseBtn'),
+    skinSelectorFull: document.getElementById('skinSelectorFull'),
+    skinCopyPromptBtn: document.getElementById('skinCopyPromptBtn'),
+    skinImportToggleBtn: document.getElementById('skinImportToggleBtn'),
+    skinImportForm: document.getElementById('skinImportForm'),
+    skinImportInput: document.getElementById('skinImportInput'),
+    skinImportSubmitBtn: document.getElementById('skinImportSubmitBtn'),
+    skinImportCancelBtn: document.getElementById('skinImportCancelBtn'),
+    skinImportError: document.getElementById('skinImportError'),
     timeFormat: document.getElementById('timeFormat'),
     weeklyDateFormat: document.getElementById('weeklyDateFormat'),
     refreshInterval: document.getElementById('refreshInterval'),
@@ -169,10 +181,17 @@ async function init() {
     setupEventListeners();
     credentials = await window.electronAPI.getCredentials();
 
-    // Apply saved theme and load thresholds immediately
+    // Apply saved theme + skin and load thresholds immediately
     const settings = await window.electronAPI.getSettings();
     window._cachedSettings = settings;
     applyTheme(settings.theme);
+    try {
+        window.SkinManager.setCustomSkins(await window.electronAPI.getCustomSkins());
+    } catch (e) {
+        debugLog('Failed to load custom skins', e);
+    }
+    renderSkinGallery(settings.skin || 'none');
+    applyGlassLevel(settings.glassLevel);
     if (window.electronAPI.platform === 'darwin') {
         document.getElementById('trayLabel').textContent = 'Hide from Dock';
     }
@@ -354,6 +373,115 @@ function setupEventListeners() {
             applyTheme(btn.dataset.theme);
         });
     });
+
+    // Skin gallery — buttons are rendered dynamically (built-ins + custom
+    // imports) into both the featured row and the full-gallery popup, so
+    // clicks on either are handled the same way via delegation.
+    function wireSkinSelectorClicks(container) {
+        if (!container) return;
+        container.addEventListener('click', async (e) => {
+            const deleteBtn = e.target.closest('.skin-preview-custom-delete');
+            if (deleteBtn) {
+                e.stopPropagation();
+                const id = deleteBtn.dataset.skinId;
+                const wasActive = window.SkinManager.getActiveSkin() === id;
+                await window.electronAPI.deleteCustomSkin(id);
+                window.SkinManager.setCustomSkins(await window.electronAPI.getCustomSkins());
+                renderSkinGallery(wasActive ? 'none' : window.SkinManager.getActiveSkin());
+                if (wasActive) await saveSettings();
+                return;
+            }
+            const btn = e.target.closest('.skin-btn');
+            if (!btn) return;
+            renderSkinGallery(btn.dataset.skin);
+            syncGlassRow();
+        });
+    }
+    wireSkinSelectorClicks(elements.skinSelector);
+    wireSkinSelectorClicks(elements.skinSelectorFull);
+
+    // "Browse all skins…" popup — a plain in-DOM overlay (never resizes the
+    // window). Closed via Done, Escape, or a click on the dimmed backdrop.
+    function openSkinPopup() {
+        if (!elements.skinPopupOverlay) return;
+        elements.skinPopupOverlay.style.display = '';
+    }
+    function closeSkinPopup() {
+        if (!elements.skinPopupOverlay) return;
+        elements.skinPopupOverlay.style.display = 'none';
+    }
+    if (elements.skinBrowseAllBtn) {
+        elements.skinBrowseAllBtn.addEventListener('click', openSkinPopup);
+    }
+    if (elements.skinPopupCloseBtn) {
+        elements.skinPopupCloseBtn.addEventListener('click', closeSkinPopup);
+    }
+    if (elements.skinPopupOverlay) {
+        elements.skinPopupOverlay.addEventListener('click', (e) => {
+            if (e.target === elements.skinPopupOverlay) closeSkinPopup();
+        });
+    }
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && elements.skinPopupOverlay && elements.skinPopupOverlay.style.display !== 'none') {
+            closeSkinPopup();
+        }
+    });
+
+    // "Copy AI prompt" — copies the full CREATING_A_SKIN.md doc (the single
+    // source of truth, baked in at build time by scripts/validate-skins.js
+    // since this app's CSP blocks fetching it at runtime) so it can be pasted
+    // straight into a Claude Code session.
+    if (elements.skinCopyPromptBtn) {
+        elements.skinCopyPromptBtn.addEventListener('click', async () => {
+            const doc = window.SKIN_AI_PROMPT_DOC || '';
+            const btn = elements.skinCopyPromptBtn;
+            const original = btn.textContent;
+            try {
+                await navigator.clipboard.writeText(doc);
+                btn.textContent = 'Copied!';
+            } catch (err) {
+                btn.textContent = 'Copy failed';
+            }
+            setTimeout(() => { btn.textContent = original; }, 1500);
+        });
+    }
+
+    // Custom skin import (paste skin.json — see skins/CREATING_A_SKIN.md)
+    if (elements.skinImportToggleBtn) {
+        elements.skinImportToggleBtn.addEventListener('click', () => {
+            const showing = elements.skinImportForm.style.display !== 'none';
+            elements.skinImportForm.style.display = showing ? 'none' : '';
+            if (!showing) elements.skinImportInput.focus();
+        });
+        elements.skinImportCancelBtn.addEventListener('click', () => {
+            elements.skinImportForm.style.display = 'none';
+            elements.skinImportInput.value = '';
+            elements.skinImportError.textContent = '';
+        });
+        elements.skinImportSubmitBtn.addEventListener('click', async () => {
+            elements.skinImportError.textContent = '';
+            const raw = elements.skinImportInput.value.trim();
+            if (!raw) {
+                elements.skinImportError.textContent = 'Paste a skin.json first.';
+                return;
+            }
+            const result = await window.electronAPI.importCustomSkin(raw);
+            if (!result.success) {
+                elements.skinImportError.textContent = result.error || 'Could not import that skin.';
+                return;
+            }
+            window.SkinManager.setCustomSkins(await window.electronAPI.getCustomSkins());
+            renderSkinGallery(result.skin.id);
+            await saveSettings();
+            elements.skinImportInput.value = '';
+            elements.skinImportForm.style.display = 'none';
+        });
+    }
+
+    const _glSelect = document.getElementById('glassLevel');
+    if (_glSelect) {
+        _glSelect.addEventListener('change', () => applyGlassLevel(_glSelect.value));
+    }
 
     // Prevent accidental app hiding: bidirectional coupling between Hide from Taskbar and Show Tray Stats
     // If user enables "Hide from Taskbar", automatically enable "Show Tray Stats" (ensures tray icon is visible)
@@ -1789,6 +1917,18 @@ async function loadSettings() {
         btn.classList.toggle('active', btn.dataset.theme === settings.theme);
     });
 
+    try {
+        window.SkinManager.setCustomSkins(await window.electronAPI.getCustomSkins());
+    } catch (e) {
+        debugLog('Failed to load custom skins', e);
+    }
+    renderSkinGallery(settings.skin || 'none');
+
+    const _gl = document.getElementById('glassLevel');
+    if (_gl) _gl.value = settings.glassLevel || 'medium';
+    applyGlassLevel(settings.glassLevel);
+    syncGlassRow();
+
     applyTheme(settings.theme);
     if (window.electronAPI.platform === 'darwin') {
         document.getElementById('trayLabel').textContent = 'Hide from Dock';
@@ -1797,6 +1937,7 @@ async function loadSettings() {
 
 async function saveSettings() {
     const activeThemeBtn = document.querySelector('.theme-btn.active');
+    const activeSkinBtn = document.querySelector('.skin-btn.active');
     const warn = parseInt(elements.warnThreshold.value) || 75;
     const danger = parseInt(elements.dangerThreshold.value) || 90;
 
@@ -1815,6 +1956,8 @@ async function saveSettings() {
         alwaysOnTop: elements.alwaysOnTopToggle.checked,
         showTrayStats: elements.showTrayStatsToggle.checked,
         theme: activeThemeBtn ? activeThemeBtn.dataset.theme : 'dark',
+        skin: activeSkinBtn ? activeSkinBtn.dataset.skin : 'none',
+        glassLevel: (document.getElementById('glassLevel') || {}).value || 'medium',
         warnThreshold: warn,
         dangerThreshold: danger,
         timeFormat: elements.timeFormat.value || '12h',
@@ -1828,6 +1971,8 @@ async function saveSettings() {
     await window.electronAPI.saveSettings(settings);
     window._cachedSettings = settings;
     applyTheme(settings.theme);
+    window.SkinManager.applySkin(settings.skin || 'none');
+    applyGlassLevel(settings.glassLevel);
     if (window.electronAPI.platform === 'darwin') {
         document.getElementById('trayLabel').textContent = 'Hide from Dock';
     }
@@ -1845,10 +1990,91 @@ async function saveSettings() {
     startAutoUpdate();
 }
 
+// Skins always shown inline in Settings, before "Browse all…" — kept short
+// on purpose so the row doesn't have to list all 10+ skins. The currently
+// active skin is always added too (below) if it isn't already one of these,
+// so switching to something from the popup never makes it "disappear".
+const FEATURED_SKIN_IDS = ['none', 'liquid', 'midnight-oled'];
+
+// Renders one skin gallery (a list of .skin-btn elements) into `container`.
+// Buttons carry the same .skin-btn/data-skin/.active contract the rest of
+// the settings code (saveSettings, syncGlassRow) already expects, so nothing
+// downstream needs to know which container — or how many skins — it's from.
+function renderSkinButtons(container, skins, activeId) {
+    if (!container) return;
+    container.innerHTML = '';
+
+    for (const skin of skins) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'skin-btn' + (skin.id === activeId ? ' active' : '');
+        btn.dataset.skin = skin.id;
+        btn.title = skin.description || skin.name;
+
+        const preview = document.createElement('span');
+        preview.className = 'skin-preview';
+        if (skin.id === 'none') {
+            preview.classList.add('skin-preview-none');
+        } else if (skin.id === 'liquid') {
+            preview.classList.add('skin-preview-liquid');
+        } else if (skin.tokens && skin.tokens['--skin-bg']) {
+            preview.style.background = skin.tokens['--skin-bg'];
+        }
+        btn.appendChild(preview);
+
+        const label = document.createElement('span');
+        label.className = 'skin-label';
+        label.textContent = skin.name;
+        btn.appendChild(label);
+
+        if (!skin.builtin) {
+            const del = document.createElement('button');
+            del.type = 'button';
+            del.className = 'skin-preview-custom-delete';
+            del.dataset.skinId = skin.id;
+            del.title = `Remove "${skin.name}"`;
+            del.textContent = '×';
+            btn.appendChild(del);
+        }
+
+        container.appendChild(btn);
+    }
+}
+
+// Rebuilds both the featured row and the full-gallery popup (None + built-in
+// presets + user-imported custom skins), and applies `activeId`.
+function renderSkinGallery(activeId) {
+    const allSkins = window.SkinManager.getAllSkins();
+
+    const featured = FEATURED_SKIN_IDS
+        .map(id => allSkins.find(s => s.id === id))
+        .filter(Boolean);
+    if (!featured.some(s => s.id === activeId)) {
+        const activeSkin = allSkins.find(s => s.id === activeId);
+        if (activeSkin) featured.push(activeSkin);
+    }
+    renderSkinButtons(elements.skinSelector, featured, activeId);
+    renderSkinButtons(elements.skinSelectorFull, allSkins, activeId);
+
+    window.SkinManager.applySkin(activeId);
+}
+
 function applyTheme(theme) {
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const useDark = theme === 'dark' || (theme === 'system' && prefersDark);
     document.body.classList.toggle('theme-light', !useDark);
+}
+
+// Liquid-skin transparency level (clear / medium / frost), via data-glass on body.
+// Harmless when another skin is active — the CSS only reacts under data-skin="liquid".
+function applyGlassLevel(level) {
+    document.body.setAttribute('data-glass', level || 'medium');
+}
+function syncGlassRow() {
+    const row = document.getElementById('glassLevelRow');
+    if (!row) return;
+    const activeSkin = document.querySelector('.skin-btn.active')?.dataset.skin || 'none';
+    row.style.display = (activeSkin === 'liquid') ? '' : 'none';
 }
 
 // Update check

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -14,10 +14,27 @@
     ">
     <title>Claude Usage Widget</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="skins/liquid.css">
+    <!-- Additional built-in preset "advanced" CSS files (beyond flat tokens)
+         get their own <link> here as they're added, same pattern as liquid.css. -->
     <script src="../../node_modules/chart.js/dist/chart.umd.js"></script>
 </head>
 
 <body>
+    <!-- Liquid skin SVG filters (hidden, referenced by CSS) -->
+    <svg id="skin-filters" aria-hidden="true" style="position:absolute;width:0;height:0;overflow:hidden;pointer-events:none;">
+        <defs>
+            <filter id="glass-distort" x="-10%" y="-10%" width="120%" height="120%">
+                <feTurbulence type="fractalNoise" baseFrequency="0.012 0.018" numOctaves="2" result="noise"/>
+                <feDisplacementMap in="SourceGraphic" in2="noise" scale="10" xChannelSelector="R" yChannelSelector="G"/>
+            </filter>
+        </defs>
+    </svg>
+
+    <!-- Skin background: blob layer sits here; widget glass layers are CSS pseudo-elements -->
+    <div id="skin-bg" aria-hidden="true">
+        <div id="skin-blobs"></div>
+    </div>
     <div id="app">
         <div class="widget-container" id="widgetContainer">
             <!-- Title Bar -->
@@ -377,6 +394,28 @@
                             </div>
                         </div>
 
+                        <!-- Row 7: featured skins — populated dynamically by SkinManager
+                             (None + Liquid + one more, plus the active skin if it isn't
+                             already among those). "Browse all…" opens the full gallery,
+                             the rest of the presets, custom import, and the AI prompt in
+                             a popup so this row doesn't have to list all 10+ skins.
+                             See skins/CREATING_A_SKIN.md for the token format. -->
+                        <div class="settings-row-full">
+                            <span class="settings-row-label">Skin</span>
+                            <div class="skin-selector" id="skinSelector"></div>
+                            <button class="skin-browse-all-btn" id="skinBrowseAllBtn" type="button">Browse all skins…</button>
+                        </div>
+
+                        <!-- Row 8: glass transparency (Liquid skin only) -->
+                        <div class="settings-row-full" id="glassLevelRow" style="display:none;">
+                            <span class="settings-row-label">Transparency</span>
+                            <select id="glassLevel" class="settings-select">
+                                <option value="clear">Clear</option>
+                                <option value="medium">Medium</option>
+                                <option value="frost">Frosted</option>
+                            </select>
+                        </div>
+
                     </div>
 
                     <div class="settings-footer">
@@ -416,9 +455,46 @@
                 </div>
             </div>
 
+            <!-- Skin gallery popup: every preset + custom skin, the custom-skin
+                 import form, and the "copy an AI prompt" action. Opened from the
+                 "Browse all skins…" button in Settings; purely an in-DOM overlay,
+                 so it never triggers a window resize. Closed via the Done button,
+                 Escape, or a click on the dimmed backdrop. -->
+            <div class="skin-popup-overlay" id="skinPopupOverlay" style="display: none;">
+                <div class="skin-popup">
+                    <div class="settings-header">
+                        <span class="settings-title">All skins</span>
+                        <button class="done-settings-btn" id="skinPopupCloseBtn" title="Done">Done</button>
+                    </div>
+                    <div class="skin-popup-body">
+                        <div class="skin-selector skin-selector-full" id="skinSelectorFull"></div>
+
+                        <div class="skin-popup-section">
+                            <span class="settings-row-label">Custom skin</span>
+                            <div class="skin-import">
+                                <div class="skin-import-controls">
+                                    <button class="skin-import-toggle-btn" id="skinImportToggleBtn" type="button">Import…</button>
+                                    <button class="skin-import-toggle-btn" id="skinCopyPromptBtn" type="button">Copy AI prompt</button>
+                                </div>
+                                <div class="skin-import-form" id="skinImportForm" style="display:none;">
+                                    <textarea id="skinImportInput" class="skin-import-textarea" rows="4" maxlength="51200" placeholder='Paste a skin.json here (see skins/CREATING_A_SKIN.md)'></textarea>
+                                    <div class="skin-import-actions">
+                                        <button class="skin-import-submit-btn" id="skinImportSubmitBtn" type="button">Add skin</button>
+                                        <button class="skin-import-cancel-btn" id="skinImportCancelBtn" type="button">Cancel</button>
+                                    </div>
+                                    <p class="skin-import-error" id="skinImportError"></p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
         </div>
     </div>
 
+    <script src="skins/presets/presets.generated.js"></script>
+    <script src="skins/skin-manager.js"></script>
     <script src="app.js"></script>
 </body>
 

--- a/src/renderer/skins/CREATING_A_SKIN.md
+++ b/src/renderer/skins/CREATING_A_SKIN.md
@@ -1,0 +1,110 @@
+# Creating a custom skin
+
+A skin is a small JSON file — a `skin.json` — that recolors the widget's chrome
+by setting a fixed set of CSS custom properties (the "token contract" below).
+You can hand-write one, tweak an existing preset, or **paste this whole file
+into a Claude Code (or any Claude) session** along with a description of the
+look you want and ask it to generate one for you. See the ready-to-use prompt
+at the bottom.
+
+## How it works
+
+- A skin only ever sets **flat values for named tokens** — colors, gradients,
+  and a couple of lengths. It cannot add CSS rules, load remote resources, or
+  run any code. This is enforced by a strict validator, not just convention.
+- Anything a skin doesn't set falls back to the app's default look, so you
+  only need to specify the tokens you actually want to change.
+- Skins **never** override what a color *means*. Session/weekly usage bars,
+  the warning/danger states, and the "on/off" status badge keep their meaning
+  (green/amber/red etc.) across every skin — a skin can only change the
+  window's chrome (background, text, borders, accent, control fills).
+
+## The shape of a skin.json
+
+```json
+{
+  "id": "my-cool-skin",
+  "name": "My Cool Skin",
+  "author": "you (optional)",
+  "description": "one line, optional",
+  "tokens": {
+    "--skin-bg": "linear-gradient(135deg, #1e1e2e 0%, #2a2a3e 100%)",
+    "--skin-text": "#e0e0e0",
+    "--skin-accent": "#8b5cf6"
+  }
+}
+```
+
+- `id`: lowercase letters, digits, and hyphens only, 2-42 characters (e.g.
+  `"sunset-vibes"`).
+- `name`: display name shown in the skin gallery, max 40 characters.
+- `author` / `description`: optional, max 40 / 200 characters.
+- `tokens`: an object using **only** the token names in the table below.
+  Unknown token names are rejected. At minimum, set `--skin-bg`, `--skin-text`,
+  and `--skin-accent` — everything else is optional polish.
+
+Nothing outside this shape is allowed: no extra top-level fields, no nested
+objects, no `advanced`/CSS field (that's reserved for the app's own built-in
+presets).
+
+## Token contract
+
+| Token | Purpose | Example |
+|---|---|---|
+| `--skin-bg` | Main widget/settings background | `linear-gradient(135deg, #1e1e2e 0%, #2a2a3e 100%)` |
+| `--skin-bg-elevated` | Title bar / settings header background | `rgba(0, 0, 0, 0.3)` |
+| `--skin-border` | Widget/control border | `rgba(255, 255, 255, 0.1)` |
+| `--skin-border-hover` | Border color on hover | `rgba(255, 255, 255, 0.25)` |
+| `--skin-hairline` | Thin dividers (under the title bar, between sections) | `rgba(255, 255, 255, 0.05)` |
+| `--skin-radius` | Corner radius of the widget/settings panel | `10px` |
+| `--skin-text` | Primary text | `#e0e0e0` |
+| `--skin-text-dim` | Secondary text (labels) | `#a0a0a0` |
+| `--skin-text-faint` | Faint/hint text | `#8f8fa0` |
+| `--skin-accent` | Brand accent color | `#8b5cf6` |
+| `--skin-accent-bg` | Translucent accent background (active pills) | `rgba(139, 92, 246, 0.2)` |
+| `--skin-accent-border` | Accent border | `rgba(139, 92, 246, 0.4)` |
+| `--skin-accent-text` | Text drawn on an accent background | `#a78bfa` |
+| `--skin-fill` | Control surface fill (buttons) | `rgba(255, 255, 255, 0.05)` |
+| `--skin-fill-hover` | Control surface fill on hover | `rgba(255, 255, 255, 0.1)` |
+| `--skin-track` | Progress-bar / timer-ring groove | `rgba(255, 255, 255, 0.1)` |
+
+**Allowed value formats:** hex colors (`#rgb`, `#rrggbb`, `#rrggbbaa`),
+`rgb()`/`rgba()`, or a `linear-gradient()`/`radial-gradient()` built only from
+those. `--skin-radius` takes a plain length like `10px` or `22`. Nothing else
+is accepted — no `url()`, no `@import`, no HTML.
+
+## Pitfalls to avoid
+
+- **Keep contrast.** `--skin-text` sits directly on `--skin-bg`; if your
+  background is light, use a dark `--skin-text` (and vice versa), or the
+  widget becomes unreadable.
+- **Don't go fully opaque black/white for `--skin-fill`/`--skin-track`** —
+  these sit *on top of* `--skin-bg`, so they need enough transparency (an
+  alpha well under 1) to read as a subtle surface rather than a solid block.
+- **Pick one `--skin-accent` family** and reuse it across
+  `--skin-accent-bg`/`--skin-accent-border`/`--skin-accent-text` at different
+  opacities — mixing unrelated hues across those four tokens looks
+  inconsistent.
+
+## Prompt to generate one
+
+Paste everything below this line into a Claude session, replace the bracketed
+description, and ask it to produce a `skin.json`:
+
+---
+
+> Using the token contract and rules in this file, generate a `skin.json` for
+> a skin themed around: **[describe the look you want, e.g. "a warm coffee-
+> shop theme, browns and cream, with a soft orange accent"]**.
+>
+> Output only the JSON object, following the shape and constraints above
+> exactly (only the listed token names, only the allowed value formats, no
+> extra fields). Make sure `--skin-text` stays readable against `--skin-bg`.
+
+---
+
+## Using it
+
+In Settings → Skin → **Import…**, paste the JSON and click **Add skin**. It's
+saved locally and appears in your skin gallery alongside the built-in
+presets; you can remove it any time with the **×** on its swatch.

--- a/src/renderer/skins/RATIONALE.md
+++ b/src/renderer/skins/RATIONALE.md
@@ -1,0 +1,49 @@
+# Why this exists
+
+The custom-skins system (presets, the token contract, and the
+import/validator/IPC/gallery-popup path) was built speculatively, not in
+response to a filed issue or user request. That's worth stating plainly
+rather than implying otherwise.
+
+Two of the ten presets have a non-decorative justification on their own —
+`high-contrast` (legibility) and `midnight-oled` (true-black power/eye-strain
+on an always-on tray element). The rest, and the whole
+import/validate/save-a-custom-skin path, are a bet that a small, frequently
+glanced-at status widget is worth letting people make their own, the same way
+Winamp/Rainmeter/terminal-color-scheme/VS-Code-theme ecosystems work — not a
+response to demonstrated demand.
+
+## What would justify keeping it
+
+- People actually use "Import…" / "Browse all skins…" — not zero clicks ever.
+- Someone asks for more presets, a different import format, or files a bug
+  against a custom skin — evidence the surface is alive, not just present.
+
+## What would justify cutting it
+
+- After a reasonable window (a few months of real usage post-release) nobody
+  has used Import and nothing above has happened — that's a sign this was
+  built ahead of demand that never showed up, and the ongoing IPC/validator
+  security-review burden isn't worth carrying for an idle feature.
+
+## If it needs to come out
+
+The import/validator/IPC/popup-gallery half is meant to be removable on its
+own, independent of the preset/token-contract plumbing everything else
+depends on:
+
+- `main.js`'s `import-custom-skin`/`get-custom-skins`/`delete-custom-skin`
+  handlers, `preload.js`'s matching bridge methods, `CREATING_A_SKIN.md`, and
+  the skin-picker UI (featured row, browse-all popup, import form,
+  copy-prompt button) in `app.js`/`index.html`/`styles.css` are the removable
+  part.
+- The 16-token `--skin-*` contract, `src/skin-validator.js` (also used
+  build-time by `scripts/validate-skins.js` to check the presets — it doesn't
+  go away just because import does), `skin-manager.js`, and the built-in
+  presets in `presets/*.json` are not — those stay regardless.
+- `findSkin()` already falls back to the `None` skin for an unrecognized id,
+  so if this is ever ripped out, anyone with a saved custom skin just stops
+  seeing it applied instead of hitting an error — no migration needed.
+
+Keep any future commit that removes the import path scoped to exactly that
+list, so it stays a clean, single revertable change.

--- a/src/renderer/skins/liquid.css
+++ b/src/renderer/skins/liquid.css
@@ -1,0 +1,584 @@
+/* ============================================================================
+   LIQUID GLASS SKIN — v3
+   ----------------------------------------------------------------------------
+   A self-contained "Liquid Glass" material, tuned for an Electron widget on a
+   transparent, frameless window.
+
+   WHY SELF-CONTAINED (not desktop refraction):
+   On Windows, `backdrop-filter` on a `transparent:true` Electron window cannot
+   blur the OS desktop behind it — it only blurs in-document content. So instead
+   of faking a broken see-through, we build the light *inside* the glass: a soft,
+   slow, brand-tinted aurora sits behind a frosted veil, finished with a real
+   specular rim. The result looks identical on any wallpaper, focused or not.
+
+   LAYER MODEL (all clipped to the rounded container, so corners are never sharp):
+     .widget-container            → the glass slab: deep base + rim + depth shadow
+     .widget-container::before    → aurora (the light within the glass), drifts slowly
+     .widget-container::after     → frost veil + top specular sheen
+     content (z-index:1)          → printed on the glass, high-contrast
+     .settings-overlay (z-index:30) → its own matching glass slab
+
+   Everything is driven by the --lg-* custom properties below, so the dark and
+   light themes share one set of structural rules and only swap the palette.
+
+   RELATIONSHIP TO THE STANDARDIZED --skin-* CONTRACT (see presets/liquid.json
+   and skins/CREATING_A_SKIN.md): Liquid is registered like any other preset,
+   with a `tokens` block mapping its palette onto the shared --skin-* names —
+   the skin registry applies those to <body> for every skin, built-in or
+   custom, so base (non-glass) chrome still resolves sensibly. This file's own
+   --lg-* selectors are higher-specificity and win for anything Liquid
+   explicitly restyles (the aurora, frost veil, rim); --lg-* stays a separate,
+   literal palette here rather than `var(--skin-*, ...)` indirection so this
+   already-tuned effect layer doesn't shift if the shared contract's defaults
+   ever change.
+   ========================================================================== */
+
+/* ── Palette: DARK (default) ─────────────────────────────────────────────── */
+body[data-skin="liquid"] {
+  /* translucent tint — the window is transparent, so this is how much real
+     desktop shows through (the see-through "glass"). Tunable via [data-glass]. */
+  --lg-scene-base: radial-gradient(140% 120% at 50% -10%, rgba(26, 22, 50, 0.52) 0%, rgba(13, 11, 24, 0.62) 100%);
+
+  /* the aurora — soft, desaturated, brand-leaning; reads as light, not neon */
+  --lg-aurora:
+    radial-gradient(38% 50% at 22% 28%, rgba(139, 110, 246, 0.50) 0%, transparent 62%),
+    radial-gradient(42% 46% at 82% 70%, rgba(56, 122, 235, 0.42) 0%, transparent 64%),
+    radial-gradient(36% 40% at 62% 14%, rgba(60, 200, 200, 0.22) 0%, transparent 60%),
+    radial-gradient(46% 44% at 14% 88%, rgba(240, 132, 96, 0.18) 0%, transparent 62%);
+
+  /* corner sheen + a light darkening for text legibility — kept thin so the
+     desktop still reads through it */
+  --lg-veil:
+    radial-gradient(120% 80% at 12% 0%, rgba(255, 255, 255, 0.12) 0%, transparent 46%),
+    radial-gradient(130% 110% at 50% 0%, rgba(14, 12, 26, 0.04) 0%, rgba(8, 6, 16, 0.22) 100%);
+
+  --lg-text:        rgba(247, 245, 255, 0.96);
+  --lg-text-dim:    rgba(223, 220, 240, 0.64);
+  --lg-text-faint:  rgba(205, 200, 232, 0.40);
+
+  --lg-accent:        #c9b8ff;            /* readable violet on dark glass */
+  --lg-accent-bg:     rgba(139, 92, 246, 0.24);
+  --lg-accent-border: rgba(159, 122, 255, 0.55);
+  --lg-accent-glow:   rgba(139, 92, 246, 0.45);
+
+  --lg-fill:         rgba(255, 255, 255, 0.07);   /* glass control surface */
+  --lg-fill-hover:   rgba(255, 255, 255, 0.14);
+  --lg-border:       rgba(255, 255, 255, 0.14);
+  --lg-border-hover: rgba(255, 255, 255, 0.30);
+
+  --lg-hairline:     rgba(255, 255, 255, 0.08);
+  --lg-track:        rgba(255, 255, 255, 0.10);
+
+  /* the specular rim that sells the glass (soft, not a hard frame) */
+  --lg-rim:        rgba(255, 255, 255, 0.50);     /* bright top sheen */
+  --lg-rim-faint:  rgba(255, 255, 255, 0.10);     /* full edge */
+  --lg-glow-top:   rgba(255, 255, 255, 0.10);
+  --lg-depth:      rgba(0, 0, 0, 0.50);           /* inner bottom shadow */
+}
+
+/* ── Palette: LIGHT ──────────────────────────────────────────────────────── */
+body[data-skin="liquid"].theme-light {
+  --lg-scene-base: radial-gradient(140% 120% at 50% -10%, rgba(252, 252, 255, 0.52) 0%, rgba(238, 240, 250, 0.62) 100%);
+
+  --lg-aurora:
+    radial-gradient(40% 52% at 20% 26%, rgba(139, 92, 246, 0.22) 0%, transparent 62%),
+    radial-gradient(44% 48% at 84% 72%, rgba(56, 128, 235, 0.18) 0%, transparent 64%),
+    radial-gradient(38% 42% at 60% 12%, rgba(45, 200, 190, 0.13) 0%, transparent 60%),
+    radial-gradient(46% 46% at 12% 90%, rgba(255, 150, 110, 0.14) 0%, transparent 62%);
+
+  --lg-veil:
+    radial-gradient(120% 80% at 12% 0%, rgba(255, 255, 255, 0.55) 0%, transparent 50%),
+    radial-gradient(130% 110% at 50% 0%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.30) 100%);
+
+  --lg-text:        #1b1830;
+  --lg-text-dim:    #4a4665;
+  --lg-text-faint:  #757090;
+
+  --lg-accent:        #7c3aed;
+  --lg-accent-bg:     rgba(139, 92, 246, 0.14);
+  --lg-accent-border: rgba(124, 58, 237, 0.42);
+  --lg-accent-glow:   rgba(139, 92, 246, 0.30);
+
+  --lg-fill:         rgba(255, 255, 255, 0.45);
+  --lg-fill-hover:   rgba(255, 255, 255, 0.70);
+  --lg-border:       rgba(120, 110, 160, 0.22);
+  --lg-border-hover: rgba(120, 110, 160, 0.40);
+
+  --lg-hairline:     rgba(40, 32, 70, 0.10);
+  --lg-track:        rgba(40, 32, 70, 0.10);
+
+  --lg-rim:        rgba(255, 255, 255, 0.95);
+  --lg-rim-faint:  rgba(255, 255, 255, 0.55);
+  --lg-glow-top:   rgba(255, 255, 255, 0.55);
+  --lg-depth:      rgba(90, 78, 130, 0.16);
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   GLASS TRANSPARENCY LEVELS
+   The window is transparent, so --lg-scene-base controls how much real desktop
+   shows through. Default (no attribute) is a balanced "medium"; an optional
+   data-glass attribute on <body> dials it clearer or more frosted.
+   ════════════════════════════════════════════════════════════════════════ */
+body[data-skin="liquid"][data-glass="clear"] {
+  --lg-scene-base: radial-gradient(140% 120% at 50% -10%, rgba(26, 22, 50, 0.30) 0%, rgba(13, 11, 24, 0.40) 100%);
+}
+body[data-skin="liquid"].theme-light[data-glass="clear"] {
+  --lg-scene-base: radial-gradient(140% 120% at 50% -10%, rgba(252, 252, 255, 0.28) 0%, rgba(238, 240, 250, 0.38) 100%);
+}
+body[data-skin="liquid"][data-glass="frost"] {
+  --lg-scene-base: radial-gradient(140% 120% at 50% -10%, rgba(24, 20, 46, 0.80) 0%, rgba(12, 10, 22, 0.86) 100%);
+}
+body[data-skin="liquid"].theme-light[data-glass="frost"] {
+  --lg-scene-base: radial-gradient(140% 120% at 50% -10%, rgba(252, 252, 255, 0.82) 0%, rgba(238, 240, 250, 0.88) 100%);
+}
+
+/* ── Root: keep the page transparent so the desktop shows through ─────────── */
+body[data-skin="liquid"] {
+  background: transparent !important;
+}
+
+/* The old full-viewport blob layer caused hard rectangular corners — kill it.
+   The scene now lives *inside* the rounded container as pseudo-elements. */
+body[data-skin="liquid"] #skin-bg {
+  display: none !important;
+}
+
+/* ── The glass slab ──────────────────────────────────────────────────────── */
+body[data-skin="liquid"] #app {
+  position: relative;
+  z-index: 1;
+  padding: 0;
+}
+
+body[data-skin="liquid"] .widget-container {
+  position: relative !important;
+  background: var(--lg-scene-base) !important;
+  border: none !important;
+  border-radius: 22px !important;
+  overflow: hidden;
+  box-shadow:
+    inset 0 1px 1px var(--lg-rim),                 /* bright top sheen, follows the curve */
+    inset 0 0 0 1px var(--lg-rim-faint),           /* faint full rim */
+    inset 0 18px 30px -20px var(--lg-glow-top),    /* soft inner top glow */
+    inset 0 -30px 50px -28px var(--lg-depth) !important;  /* inner bottom depth = thickness */
+}
+
+/* Aurora — the light within the glass. Drifts slowly; transform-only (cheap). */
+body[data-skin="liquid"] .widget-container::before {
+  content: '';
+  position: absolute;
+  inset: -25%;
+  background: var(--lg-aurora);
+  z-index: 0;
+  pointer-events: none;
+  will-change: transform;
+  animation: lg-drift 34s ease-in-out infinite alternate;
+}
+
+/* Frost veil + corner sheen — painted over the aurora to make it milky glass */
+body[data-skin="liquid"] .widget-container::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--lg-veil);
+  z-index: 0;
+  pointer-events: none;
+}
+
+/* All real content rides above the two glass layers */
+body[data-skin="liquid"] .widget-container > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ...except the settings overlays, which must stay as covering layers.
+   The rule above would otherwise knock them into normal flow, so the main
+   widget would show *above* the panel instead of being covered by it. */
+body[data-skin="liquid"] .settings-overlay {
+  position: absolute !important;
+  inset: 0 !important;
+}
+
+/* Skin popup sits above .settings-overlay (z-index 30) — same reassertion,
+   needed because body[data-skin="liquid"] .widget-container > * forces
+   position:relative on every direct child, this overlay included. */
+body[data-skin="liquid"] .skin-popup-overlay {
+  position: absolute !important;
+  inset: 0 !important;
+  z-index: 40 !important;
+}
+
+@keyframes lg-drift {
+  0%   { transform: translate3d(0, 0, 0) scale(1); }
+  50%  { transform: translate3d(2.5%, -2%, 0) scale(1.06); }
+  100% { transform: translate3d(-2%, 2.5%, 0) scale(1.03); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-skin="liquid"] .widget-container::before { animation: none; }
+}
+
+/* ── Title bar ───────────────────────────────────────────────────────────── */
+body[data-skin="liquid"] .title-bar {
+  background: transparent !important;
+  border-bottom: 1px solid var(--lg-hairline) !important;
+  box-shadow: 0 1px 0 var(--lg-rim-faint);
+}
+
+body[data-skin="liquid"] .title {
+  color: var(--lg-text);
+}
+body[data-skin="liquid"]:not(.theme-light) .title {
+  text-shadow: 0 0 16px rgba(180, 150, 255, 0.25);
+}
+body[data-skin="liquid"] .app-logo { opacity: 0.95; }
+
+/* ── Control buttons — glass pills ───────────────────────────────────────── */
+body[data-skin="liquid"] .control-btn {
+  background: var(--lg-fill);
+  border: 1px solid var(--lg-border);
+  color: var(--lg-text-dim);
+  box-shadow: inset 0 1px 0 var(--lg-rim-faint);
+  transition: all 0.18s ease;
+}
+body[data-skin="liquid"] .control-btn:hover {
+  background: var(--lg-fill-hover);
+  border-color: var(--lg-border-hover);
+  color: var(--lg-text);
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 var(--lg-rim),
+    0 4px 14px var(--lg-accent-glow);
+}
+body[data-skin="liquid"] .close-btn:hover {
+  background: rgba(231, 76, 60, 0.92) !important;
+  border-color: rgba(231, 76, 60, 0.9);
+  color: #fff;
+  box-shadow: 0 4px 14px rgba(231, 76, 60, 0.45);
+}
+
+/* ── States shown before the main content (readable on glass) ────────────── */
+body[data-skin="liquid"] .loading-container,
+body[data-skin="liquid"] .loading-container p { color: var(--lg-text-dim); }
+body[data-skin="liquid"] .spinner {
+  border-color: var(--lg-track);
+  border-top-color: var(--lg-accent);
+}
+body[data-skin="liquid"] .step-text h3,
+body[data-skin="liquid"] .session-key-header h3,
+body[data-skin="liquid"] .no-usage-content h3 { color: var(--lg-text); }
+body[data-skin="liquid"] .step-text p,
+body[data-skin="liquid"] .session-key-header p,
+body[data-skin="liquid"] .no-usage-content p { color: var(--lg-text-dim); }
+body[data-skin="liquid"] .step-icon svg,
+body[data-skin="liquid"] .no-usage-content svg { color: var(--lg-accent); }
+
+/* ── Column headers + labels ─────────────────────────────────────────────── */
+body[data-skin="liquid"] .col-header        { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .usage-label       { color: var(--lg-text-dim); }
+body[data-skin="liquid"] .usage-percentage,
+body[data-skin="liquid"] .timer-text        { color: var(--lg-text); }
+body[data-skin="liquid"] .resets-at-text    { color: var(--lg-text-faint); }
+
+/* ── Progress bars — keep semantic colours, add a glassy gloss ───────────── */
+body[data-skin="liquid"] .progress-bar {
+  background: var(--lg-track);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.22);
+  overflow: hidden;
+}
+/* gloss line on the fill (no hue change — danger/warning stay meaningful) */
+body[data-skin="liquid"] .progress-fill {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.45),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.18);
+}
+body[data-skin="liquid"] .progress-fill::after {
+  content: '';
+  position: absolute;
+  inset: 0 0 50% 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.28), transparent);
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+/* ── Timer rings — keep semantic stroke, add a soft glow ─────────────────── */
+body[data-skin="liquid"] .timer-bg { stroke: var(--lg-track); }
+body[data-skin="liquid"] .timer-progress {
+  filter: drop-shadow(0 0 3px var(--lg-accent-glow));
+}
+
+/* ── Expand / sections ───────────────────────────────────────────────────── */
+body[data-skin="liquid"] .expand-arrow { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .expand-toggle:hover .expand-arrow { color: var(--lg-accent); }
+body[data-skin="liquid"] .expand-section,
+body[data-skin="liquid"] .graph-section,
+body[data-skin="liquid"] #multiAccountSection {
+  border-top: 1px solid var(--lg-hairline) !important;
+}
+body[data-skin="liquid"] .expand-section .usage-label { color: var(--lg-text-faint); }
+
+/* extra-usage status pill keeps its on/off semantics */
+body[data-skin="liquid"] .active-account-name {
+  color: var(--lg-accent);
+}
+body[data-skin="liquid"]:not(.theme-light) .active-account-name {
+  text-shadow: 0 0 10px var(--lg-accent-glow);
+}
+body[data-skin="liquid"] .all-accounts-btn.active { color: #6db1ff; }
+
+/* ── Multi-account section ───────────────────────────────────────────────── */
+body[data-skin="liquid"] .multi-account-label     { color: var(--lg-text-dim); }
+body[data-skin="liquid"] .multi-account-row-label { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .multi-account-pct       { color: var(--lg-text); }
+body[data-skin="liquid"] .multi-account-time      { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .multi-account-bar-bg    { background: var(--lg-track); }
+
+/* ── Compact mode ────────────────────────────────────────────────────────── */
+body[data-skin="liquid"] .compact-label { color: var(--lg-text-dim); }
+body[data-skin="liquid"] .compact-pct   { color: var(--lg-text); }
+body[data-skin="liquid"] .compact-bar-bg {
+  background: var(--lg-track);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.22);
+}
+body[data-skin="liquid"] .compact-bar-fill {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+body[data-skin="liquid"] .compact-collapse-btn,
+body[data-skin="liquid"] .compact-expand-btn { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .compact-collapse-btn:hover,
+body[data-skin="liquid"] .compact-expand-btn:hover { color: var(--lg-accent); }
+
+/* ── Update banner ───────────────────────────────────────────────────────── */
+body[data-skin="liquid"] .update-banner {
+  background: var(--lg-accent-bg) !important;
+  border-bottom: 1px solid var(--lg-accent-border);
+}
+body[data-skin="liquid"] .update-banner-text,
+body[data-skin="liquid"] .update-banner-dismiss { color: var(--lg-accent); }
+
+/* ════════════════════════════════════════════════════════════════════════
+   SETTINGS — rebuilt as its own matching glass slab (was the broken part)
+   ════════════════════════════════════════════════════════════════════════ */
+body[data-skin="liquid"] .settings-overlay {
+  background: var(--lg-scene-base) !important;
+  border: none !important;
+  border-radius: 22px !important;
+  overflow: hidden;
+  z-index: 30 !important;
+  box-shadow:
+    inset 0 1px 1px var(--lg-rim),
+    inset 0 0 0 1px var(--lg-rim-faint),
+    inset 0 18px 30px -20px var(--lg-glow-top),
+    inset 0 -30px 50px -28px var(--lg-depth) !important;
+  /* no backdrop-filter: the overlay fully covers the widget, so there is
+     nothing meaningful behind it to blur — blurring only muddied it before */
+}
+body[data-skin="liquid"] .settings-overlay::before {
+  content: '';
+  position: absolute;
+  inset: -25%;
+  background: var(--lg-aurora);
+  z-index: 0;
+  pointer-events: none;
+  will-change: transform;
+  animation: lg-drift 40s ease-in-out infinite alternate;
+}
+body[data-skin="liquid"] .settings-overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--lg-veil);
+  z-index: 0;
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  body[data-skin="liquid"] .settings-overlay::before { animation: none; }
+}
+body[data-skin="liquid"] .settings-content {
+  position: relative;
+  z-index: 1;
+}
+
+/* header */
+body[data-skin="liquid"] .settings-header {
+  background: transparent !important;
+  border-bottom: 1px solid var(--lg-hairline) !important;
+  box-shadow: 0 1px 0 var(--lg-rim-faint);
+}
+body[data-skin="liquid"] .settings-title { color: var(--lg-text); }
+body[data-skin="liquid"] .done-settings-btn {
+  background: var(--lg-accent-bg);
+  border: 1px solid var(--lg-accent-border);
+  color: var(--lg-accent);
+  box-shadow: inset 0 1px 0 var(--lg-rim-faint);
+}
+body[data-skin="liquid"] .done-settings-btn:hover {
+  background: var(--lg-accent-bg);
+  border-color: var(--lg-accent-border);
+  color: var(--lg-text);
+  box-shadow: inset 0 1px 0 var(--lg-rim), 0 3px 12px var(--lg-accent-glow);
+}
+
+body[data-skin="liquid"] .settings-disclaimer {
+  color: var(--lg-text-faint);
+  border-bottom: 1px solid var(--lg-hairline) !important;
+}
+
+/* labels + hints */
+body[data-skin="liquid"] .settings-row-label { color: var(--lg-text-dim); }
+body[data-skin="liquid"] .settings-row-hint  { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .settings-col-disabled .settings-row-label { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .settings-row-full  { border-bottom: 1px solid var(--lg-hairline); }
+body[data-skin="liquid"] .threshold-pct { color: var(--lg-text-faint); }
+
+/* toggle switches */
+body[data-skin="liquid"] .toggle-slider {
+  background: var(--lg-track);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+body[data-skin="liquid"] .toggle-slider::before {
+  background: var(--lg-text-dim);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+body[data-skin="liquid"] input:checked + .toggle-slider {
+  background: var(--lg-accent-bg);
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.15),
+    0 0 10px var(--lg-accent-glow);
+}
+body[data-skin="liquid"] input:checked + .toggle-slider::before {
+  background: var(--lg-accent);
+}
+
+/* segmented buttons: theme + skin */
+body[data-skin="liquid"] .theme-btn,
+body[data-skin="liquid"] .skin-btn {
+  background: var(--lg-fill);
+  border: 1px solid var(--lg-border);
+  color: var(--lg-text-dim);
+  box-shadow: inset 0 1px 0 var(--lg-rim-faint);
+}
+body[data-skin="liquid"] .theme-btn:hover,
+body[data-skin="liquid"] .skin-btn:hover {
+  border-color: var(--lg-border-hover);
+  color: var(--lg-text);
+}
+body[data-skin="liquid"] .theme-btn.active,
+body[data-skin="liquid"] .skin-btn.active {
+  background: var(--lg-accent-bg);
+  border-color: var(--lg-accent-border);
+  color: var(--lg-accent);
+  box-shadow: inset 0 1px 0 var(--lg-rim), 0 0 12px var(--lg-accent-glow);
+}
+
+/* selects */
+body[data-skin="liquid"] .settings-select {
+  background: var(--lg-fill);
+  border: 1px solid var(--lg-border);
+  color: var(--lg-text);
+  box-shadow: inset 0 1px 0 var(--lg-rim-faint);
+}
+body[data-skin="liquid"] .settings-select:hover { border-color: var(--lg-border-hover); }
+body[data-skin="liquid"] .settings-select:focus {
+  border-color: var(--lg-accent-border);
+  box-shadow: 0 0 0 2px var(--lg-accent-glow);
+}
+body[data-skin="liquid"]:not(.theme-light) .settings-select option { background: #16132a; color: var(--lg-text); }
+body[data-skin="liquid"].theme-light .settings-select option { background: #ffffff; color: #1b1830; }
+
+/* threshold number inputs */
+body[data-skin="liquid"] .threshold-input {
+  background: var(--lg-fill);
+  border: 1px solid var(--lg-border);
+  color: var(--lg-text);
+  box-shadow: inset 0 1px 0 var(--lg-rim-faint);
+}
+body[data-skin="liquid"] .threshold-input:focus { border-color: var(--lg-accent-border); }
+
+/* accounts */
+body[data-skin="liquid"] .accounts-section { border-top: 1px solid var(--lg-hairline); }
+body[data-skin="liquid"] .accounts-title   { color: var(--lg-text-dim); }
+body[data-skin="liquid"] .add-account-btn {
+  background: var(--lg-accent-bg);
+  border: 1px solid var(--lg-accent-border);
+  color: var(--lg-accent);
+}
+body[data-skin="liquid"] .add-account-btn:hover { box-shadow: 0 0 10px var(--lg-accent-glow); }
+body[data-skin="liquid"] .account-item {
+  background: var(--lg-fill);
+  border: 1px solid var(--lg-border);
+  box-shadow: inset 0 1px 0 var(--lg-rim-faint);
+}
+body[data-skin="liquid"] .account-item.active {
+  background: var(--lg-accent-bg);
+  border-color: var(--lg-accent-border);
+}
+body[data-skin="liquid"] .account-dot { background: var(--lg-text-faint); }
+body[data-skin="liquid"] .account-item.active .account-dot { background: var(--lg-accent); }
+body[data-skin="liquid"] .account-label { color: var(--lg-text-dim); }
+body[data-skin="liquid"] .account-item.active .account-label { color: var(--lg-text); }
+body[data-skin="liquid"] .account-active-badge { color: var(--lg-accent); }
+body[data-skin="liquid"] .account-switch-btn {
+  background: var(--lg-fill);
+  border: 1px solid var(--lg-border);
+  color: var(--lg-text-dim);
+}
+body[data-skin="liquid"] .account-switch-btn:hover { color: var(--lg-accent); background: var(--lg-accent-bg); }
+body[data-skin="liquid"] .account-delete-btn { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .account-delete-btn:hover { color: #ff6b6b; }
+body[data-skin="liquid"] .account-label-input {
+  background: var(--lg-fill);
+  border: 1px solid var(--lg-accent-border);
+  color: var(--lg-text);
+}
+body[data-skin="liquid"] .save-account-btn {
+  background: var(--lg-accent-bg);
+  border: 1px solid var(--lg-accent-border);
+  color: var(--lg-accent);
+}
+body[data-skin="liquid"] .cancel-account-btn {
+  background: var(--lg-fill);
+  border: 1px solid var(--lg-border);
+  color: var(--lg-text-dim);
+}
+
+/* footer */
+body[data-skin="liquid"] .settings-footer { border-top: 1px solid var(--lg-hairline) !important; }
+body[data-skin="liquid"] .settings-version-label { color: var(--lg-text-faint); }
+body[data-skin="liquid"] .logout-btn {
+  color: #ff7a7a;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  background: transparent;
+}
+body[data-skin="liquid"] .logout-btn:hover {
+  background: rgba(239, 68, 68, 0.16);
+  border-color: rgba(239, 68, 68, 0.7);
+}
+body[data-skin="liquid"] .coffee-btn {
+  background: rgba(245, 184, 64, 0.14);
+  color: #f6c453;
+  border: 1px solid rgba(245, 184, 64, 0.32);
+  box-shadow: inset 0 1px 0 var(--lg-rim-faint);
+}
+body[data-skin="liquid"] .coffee-btn:hover {
+  background: rgba(245, 184, 64, 0.22);
+  border-color: rgba(245, 184, 64, 0.5);
+}
+body[data-skin="liquid"].theme-light .coffee-btn { color: #b07807; }
+
+/* ── Scrollbar ───────────────────────────────────────────────────────────── */
+body[data-skin="liquid"] ::-webkit-scrollbar-thumb {
+  background: var(--lg-border);
+  border-radius: 4px;
+}
+body[data-skin="liquid"] ::-webkit-scrollbar-thumb:hover { background: var(--lg-border-hover); }
+
+/* ── Skin-picker preview swatch (in settings) ────────────────────────────── */
+.skin-preview-liquid {
+  background:
+    radial-gradient(60% 60% at 25% 25%, rgba(160, 130, 255, 0.95) 0%, transparent 70%),
+    radial-gradient(60% 60% at 80% 75%, rgba(80, 150, 245, 0.9) 0%, transparent 70%),
+    linear-gradient(135deg, #2a2150 0%, #141233 100%);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}

--- a/src/renderer/skins/presets/corporate-slate.json
+++ b/src/renderer/skins/presets/corporate-slate.json
@@ -1,0 +1,24 @@
+{
+  "id": "corporate-slate",
+  "name": "Corporate Slate",
+  "author": "Hebbala LLC",
+  "description": "Neutral slate gray with a professional blue accent — built for white-labeling.",
+  "tokens": {
+    "--skin-bg": "linear-gradient(135deg, #232a33 0%, #2d3540 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.25)",
+    "--skin-border": "rgba(180, 195, 210, 0.14)",
+    "--skin-border-hover": "rgba(180, 195, 210, 0.3)",
+    "--skin-hairline": "rgba(180, 195, 210, 0.09)",
+    "--skin-radius": "8px",
+    "--skin-text": "#e6ecf2",
+    "--skin-text-dim": "#a8b6c4",
+    "--skin-text-faint": "#76869a",
+    "--skin-accent": "#4f9dde",
+    "--skin-accent-bg": "rgba(79, 157, 222, 0.18)",
+    "--skin-accent-border": "rgba(79, 157, 222, 0.42)",
+    "--skin-accent-text": "#7cbaea",
+    "--skin-fill": "rgba(255, 255, 255, 0.05)",
+    "--skin-fill-hover": "rgba(255, 255, 255, 0.1)",
+    "--skin-track": "rgba(255, 255, 255, 0.09)"
+  }
+}

--- a/src/renderer/skins/presets/cyberpunk-neon.json
+++ b/src/renderer/skins/presets/cyberpunk-neon.json
@@ -1,0 +1,24 @@
+{
+  "id": "cyberpunk-neon",
+  "name": "Cyberpunk Neon",
+  "author": "Hebbala LLC",
+  "description": "Hot pink on near-black with a neon-cyan edge.",
+  "tokens": {
+    "--skin-bg": "linear-gradient(135deg, #0c0416 0%, #170826 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.4)",
+    "--skin-border": "rgba(255, 60, 172, 0.3)",
+    "--skin-border-hover": "rgba(0, 240, 255, 0.5)",
+    "--skin-hairline": "rgba(255, 60, 172, 0.18)",
+    "--skin-radius": "6px",
+    "--skin-text": "#f5e9ff",
+    "--skin-text-dim": "#c79fe0",
+    "--skin-text-faint": "#8a63a3",
+    "--skin-accent": "#ff3cac",
+    "--skin-accent-bg": "rgba(255, 60, 172, 0.2)",
+    "--skin-accent-border": "rgba(255, 60, 172, 0.55)",
+    "--skin-accent-text": "#00f0ff",
+    "--skin-fill": "rgba(255, 60, 172, 0.08)",
+    "--skin-fill-hover": "rgba(0, 240, 255, 0.12)",
+    "--skin-track": "rgba(255, 60, 172, 0.14)"
+  }
+}

--- a/src/renderer/skins/presets/forest.json
+++ b/src/renderer/skins/presets/forest.json
@@ -1,0 +1,24 @@
+{
+  "id": "forest",
+  "name": "Forest",
+  "author": "Hebbala LLC",
+  "description": "Deep earthy green with a bright leaf accent.",
+  "tokens": {
+    "--skin-bg": "linear-gradient(135deg, #10201a 0%, #16281f 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.3)",
+    "--skin-border": "rgba(150, 210, 170, 0.12)",
+    "--skin-border-hover": "rgba(150, 210, 170, 0.28)",
+    "--skin-hairline": "rgba(150, 210, 170, 0.08)",
+    "--skin-radius": "10px",
+    "--skin-text": "#e6f2e9",
+    "--skin-text-dim": "#a9c4b2",
+    "--skin-text-faint": "#749381",
+    "--skin-accent": "#5fd88a",
+    "--skin-accent-bg": "rgba(95, 216, 138, 0.18)",
+    "--skin-accent-border": "rgba(95, 216, 138, 0.42)",
+    "--skin-accent-text": "#8fe8ac",
+    "--skin-fill": "rgba(255, 255, 255, 0.05)",
+    "--skin-fill-hover": "rgba(255, 255, 255, 0.1)",
+    "--skin-track": "rgba(255, 255, 255, 0.09)"
+  }
+}

--- a/src/renderer/skins/presets/high-contrast.json
+++ b/src/renderer/skins/presets/high-contrast.json
@@ -1,0 +1,24 @@
+{
+  "id": "high-contrast",
+  "name": "High Contrast",
+  "author": "Hebbala LLC",
+  "description": "Max-legibility accessibility skin — pure black/white with a yellow accent.",
+  "tokens": {
+    "--skin-bg": "#000000",
+    "--skin-bg-elevated": "#000000",
+    "--skin-border": "#ffffff",
+    "--skin-border-hover": "#ffd700",
+    "--skin-hairline": "rgba(255, 255, 255, 0.4)",
+    "--skin-radius": "6px",
+    "--skin-text": "#ffffff",
+    "--skin-text-dim": "#e0e0e0",
+    "--skin-text-faint": "#b0b0b0",
+    "--skin-accent": "#ffd700",
+    "--skin-accent-bg": "rgba(255, 215, 0, 0.22)",
+    "--skin-accent-border": "#ffd700",
+    "--skin-accent-text": "#ffd700",
+    "--skin-fill": "rgba(255, 255, 255, 0.1)",
+    "--skin-fill-hover": "rgba(255, 255, 255, 0.2)",
+    "--skin-track": "rgba(255, 255, 255, 0.2)"
+  }
+}

--- a/src/renderer/skins/presets/liquid.json
+++ b/src/renderer/skins/presets/liquid.json
@@ -1,0 +1,25 @@
+{
+  "id": "liquid",
+  "name": "Liquid",
+  "author": "Hebbala LLC",
+  "description": "Self-contained frosted glass with a drifting brand-tinted aurora.",
+  "tokens": {
+    "--skin-bg": "radial-gradient(140% 120% at 50% -10%, rgba(26, 22, 50, 0.52) 0%, rgba(13, 11, 24, 0.62) 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.3)",
+    "--skin-border": "rgba(255, 255, 255, 0.14)",
+    "--skin-border-hover": "rgba(255, 255, 255, 0.30)",
+    "--skin-hairline": "rgba(255, 255, 255, 0.08)",
+    "--skin-radius": "22px",
+    "--skin-text": "rgba(247, 245, 255, 0.96)",
+    "--skin-text-dim": "rgba(223, 220, 240, 0.64)",
+    "--skin-text-faint": "rgba(205, 200, 232, 0.40)",
+    "--skin-accent": "#c9b8ff",
+    "--skin-accent-bg": "rgba(139, 92, 246, 0.24)",
+    "--skin-accent-border": "rgba(159, 122, 255, 0.55)",
+    "--skin-accent-text": "#c9b8ff",
+    "--skin-fill": "rgba(255, 255, 255, 0.07)",
+    "--skin-fill-hover": "rgba(255, 255, 255, 0.14)",
+    "--skin-track": "rgba(255, 255, 255, 0.10)"
+  },
+  "advanced": "liquid.css"
+}

--- a/src/renderer/skins/presets/midnight-oled.json
+++ b/src/renderer/skins/presets/midnight-oled.json
@@ -1,0 +1,24 @@
+{
+  "id": "midnight-oled",
+  "name": "Midnight OLED",
+  "author": "Hebbala LLC",
+  "description": "True black for OLED screens, minimal and high-contrast.",
+  "tokens": {
+    "--skin-bg": "linear-gradient(135deg, #000000 0%, #060608 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.6)",
+    "--skin-border": "rgba(255, 255, 255, 0.08)",
+    "--skin-border-hover": "rgba(255, 255, 255, 0.22)",
+    "--skin-hairline": "rgba(255, 255, 255, 0.06)",
+    "--skin-radius": "10px",
+    "--skin-text": "#f2f2f5",
+    "--skin-text-dim": "#8a8a92",
+    "--skin-text-faint": "#5c5c66",
+    "--skin-accent": "#4fd6ff",
+    "--skin-accent-bg": "rgba(79, 214, 255, 0.16)",
+    "--skin-accent-border": "rgba(79, 214, 255, 0.4)",
+    "--skin-accent-text": "#8fe6ff",
+    "--skin-fill": "rgba(255, 255, 255, 0.04)",
+    "--skin-fill-hover": "rgba(255, 255, 255, 0.09)",
+    "--skin-track": "rgba(255, 255, 255, 0.08)"
+  }
+}

--- a/src/renderer/skins/presets/monochrome.json
+++ b/src/renderer/skins/presets/monochrome.json
@@ -1,0 +1,24 @@
+{
+  "id": "monochrome",
+  "name": "Monochrome",
+  "author": "Hebbala LLC",
+  "description": "Pure grayscale — no hue anywhere, including the accent.",
+  "tokens": {
+    "--skin-bg": "linear-gradient(135deg, #1c1c1c 0%, #262626 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.32)",
+    "--skin-border": "rgba(255, 255, 255, 0.12)",
+    "--skin-border-hover": "rgba(255, 255, 255, 0.28)",
+    "--skin-hairline": "rgba(255, 255, 255, 0.07)",
+    "--skin-radius": "8px",
+    "--skin-text": "#f0f0f0",
+    "--skin-text-dim": "#a3a3a3",
+    "--skin-text-faint": "#707070",
+    "--skin-accent": "#d4d4d4",
+    "--skin-accent-bg": "rgba(255, 255, 255, 0.16)",
+    "--skin-accent-border": "rgba(255, 255, 255, 0.4)",
+    "--skin-accent-text": "#f5f5f5",
+    "--skin-fill": "rgba(255, 255, 255, 0.06)",
+    "--skin-fill-hover": "rgba(255, 255, 255, 0.12)",
+    "--skin-track": "rgba(255, 255, 255, 0.1)"
+  }
+}

--- a/src/renderer/skins/presets/pastel.json
+++ b/src/renderer/skins/presets/pastel.json
@@ -1,0 +1,24 @@
+{
+  "id": "pastel",
+  "name": "Pastel",
+  "author": "Hebbala LLC",
+  "description": "Soft lavender-and-blush light theme with a muted violet accent.",
+  "tokens": {
+    "--skin-bg": "linear-gradient(135deg, #f6eefc 0%, #fdeef4 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.04)",
+    "--skin-border": "rgba(150, 110, 180, 0.16)",
+    "--skin-border-hover": "rgba(150, 110, 180, 0.32)",
+    "--skin-hairline": "rgba(150, 110, 180, 0.12)",
+    "--skin-radius": "16px",
+    "--skin-text": "#4a3a55",
+    "--skin-text-dim": "#8a7595",
+    "--skin-text-faint": "#b3a2bd",
+    "--skin-accent": "#b47ee0",
+    "--skin-accent-bg": "rgba(180, 126, 224, 0.16)",
+    "--skin-accent-border": "rgba(180, 126, 224, 0.4)",
+    "--skin-accent-text": "#8b4fc4",
+    "--skin-fill": "rgba(0, 0, 0, 0.035)",
+    "--skin-fill-hover": "rgba(0, 0, 0, 0.07)",
+    "--skin-track": "rgba(0, 0, 0, 0.08)"
+  }
+}

--- a/src/renderer/skins/presets/retro-terminal.json
+++ b/src/renderer/skins/presets/retro-terminal.json
@@ -1,0 +1,24 @@
+{
+  "id": "retro-terminal",
+  "name": "Retro Terminal",
+  "author": "Hebbala LLC",
+  "description": "Phosphor-green CRT terminal look on near-black.",
+  "tokens": {
+    "--skin-bg": "linear-gradient(135deg, #030a03 0%, #0a140a 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.5)",
+    "--skin-border": "rgba(70, 255, 120, 0.25)",
+    "--skin-border-hover": "rgba(70, 255, 120, 0.5)",
+    "--skin-hairline": "rgba(70, 255, 120, 0.15)",
+    "--skin-radius": "4px",
+    "--skin-text": "#a8ffb0",
+    "--skin-text-dim": "#5fcf70",
+    "--skin-text-faint": "#3a8a45",
+    "--skin-accent": "#46ff78",
+    "--skin-accent-bg": "rgba(70, 255, 120, 0.16)",
+    "--skin-accent-border": "rgba(70, 255, 120, 0.5)",
+    "--skin-accent-text": "#7dffa0",
+    "--skin-fill": "rgba(70, 255, 120, 0.06)",
+    "--skin-fill-hover": "rgba(70, 255, 120, 0.12)",
+    "--skin-track": "rgba(70, 255, 120, 0.12)"
+  }
+}

--- a/src/renderer/skins/presets/sunset.json
+++ b/src/renderer/skins/presets/sunset.json
@@ -1,0 +1,24 @@
+{
+  "id": "sunset",
+  "name": "Sunset",
+  "author": "Hebbala LLC",
+  "description": "Warm dusk gradient with an amber glow.",
+  "tokens": {
+    "--skin-bg": "linear-gradient(160deg, #2b1730 0%, #4a1f2e 55%, #602a24 100%)",
+    "--skin-bg-elevated": "rgba(0, 0, 0, 0.28)",
+    "--skin-border": "rgba(255, 200, 160, 0.16)",
+    "--skin-border-hover": "rgba(255, 200, 160, 0.32)",
+    "--skin-hairline": "rgba(255, 200, 160, 0.10)",
+    "--skin-radius": "14px",
+    "--skin-text": "#fbe9dd",
+    "--skin-text-dim": "#d9b3a4",
+    "--skin-text-faint": "#a97e70",
+    "--skin-accent": "#ff9a56",
+    "--skin-accent-bg": "rgba(255, 154, 86, 0.2)",
+    "--skin-accent-border": "rgba(255, 154, 86, 0.45)",
+    "--skin-accent-text": "#ffb684",
+    "--skin-fill": "rgba(255, 255, 255, 0.06)",
+    "--skin-fill-hover": "rgba(255, 255, 255, 0.12)",
+    "--skin-track": "rgba(255, 255, 255, 0.10)"
+  }
+}

--- a/src/renderer/skins/skin-manager.js
+++ b/src/renderer/skins/skin-manager.js
@@ -1,0 +1,73 @@
+// Skin manager — dynamic registry of built-in presets + user-imported custom
+// skins, all driven by the standardized --skin-* token contract (see
+// CREATING_A_SKIN.md). Applying a skin means: set `data-skin` on <body> (only
+// "liquid" reacts to this today, via its own bundled CSS) and set every
+// --skin-* custom property the skin's manifest defines as an inline style on
+// <body> — never by injecting a raw CSS/style string, since custom skins may
+// originate from pasted/AI-generated content. Built-in preset CSS files are
+// pre-linked in index.html; presets.generated.js is a plain <script> include
+// too (this app's CSP sets connect-src 'none', so nothing here ever fetches).
+
+// Generated from src/skin-validator.js's KNOWN_TOKENS by
+// scripts/validate-skins.js (see presets.generated.js) — never hand-edit
+// this list here, it would just drift from the validator's allow-list.
+const KNOWN_SKIN_TOKENS = Array.isArray(window.SKIN_KNOWN_TOKENS) ? window.SKIN_KNOWN_TOKENS : [];
+
+const NONE_SKIN = { id: 'none', name: 'None', builtin: true, tokens: {} };
+
+let customSkins = [];
+
+function builtInPresets() {
+  return Array.isArray(window.SKIN_PRESETS)
+    ? window.SKIN_PRESETS.map(s => ({ ...s, builtin: true }))
+    : [];
+}
+
+function getAllSkins() {
+  return [NONE_SKIN, ...builtInPresets(), ...customSkins.map(s => ({ ...s, builtin: false }))];
+}
+
+function findSkin(id) {
+  return getAllSkins().find(s => s.id === id) || NONE_SKIN;
+}
+
+function applySkin(id) {
+  const skin = findSkin(id);
+
+  if (skin.id === 'none') {
+    document.body.removeAttribute('data-skin');
+  } else {
+    document.body.setAttribute('data-skin', skin.id);
+  }
+
+  // Clear every known token first so a skin that doesn't set a given token
+  // falls back to the base/theme default instead of inheriting a stale
+  // value left over from the previously active skin.
+  for (const token of KNOWN_SKIN_TOKENS) {
+    document.body.style.removeProperty(token);
+  }
+  for (const [name, value] of Object.entries(skin.tokens || {})) {
+    if (KNOWN_SKIN_TOKENS.includes(name)) {
+      document.body.style.setProperty(name, value);
+    }
+  }
+}
+
+function getActiveSkin() {
+  return document.body.getAttribute('data-skin') || 'none';
+}
+
+// Called once at startup (and after a successful import/delete) with the
+// current custom-skin list from the main process store.
+function setCustomSkins(skins) {
+  customSkins = Array.isArray(skins) ? skins : [];
+}
+
+window.SkinManager = {
+  applySkin,
+  getActiveSkin,
+  getAllSkins,
+  findSkin,
+  setCustomSkins,
+  KNOWN_SKIN_TOKENS,
+};

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -21,6 +21,52 @@
     /* Remove default focus outline */
 }
 
+/* ============================================================================
+   SKIN TOKEN CONTRACT — the standardized set every skin (including the
+   default "None" skin below) sets to retheme the app's chrome. A skin sets
+   these on `body` (or `body[data-skin="x"]`); it does NOT touch the semantic
+   usage-bar colors (session/weekly/warning/danger/extra/etc — those keep
+   their meaning across every skin). See skins/CREATING_A_SKIN.md.
+   ========================================================================== */
+:root {
+    --skin-bg: linear-gradient(135deg, #1e1e2e 0%, #2a2a3e 100%);
+    --skin-bg-elevated: rgba(0, 0, 0, 0.3);
+    --skin-border: rgba(255, 255, 255, 0.1);
+    --skin-border-hover: rgba(255, 255, 255, 0.25);
+    --skin-hairline: rgba(255, 255, 255, 0.05);
+    --skin-radius: 10px;
+
+    --skin-text: #e0e0e0;
+    --skin-text-dim: #a0a0a0;
+    --skin-text-faint: #8f8fa0;
+
+    --skin-accent: #8b5cf6;
+    --skin-accent-bg: rgba(139, 92, 246, 0.2);
+    --skin-accent-border: rgba(139, 92, 246, 0.4);
+    --skin-accent-text: #a78bfa;
+
+    --skin-fill: rgba(255, 255, 255, 0.05);
+    --skin-fill-hover: rgba(255, 255, 255, 0.1);
+    --skin-track: rgba(255, 255, 255, 0.1);
+}
+
+body.theme-light {
+    --skin-bg: linear-gradient(135deg, #f0f0f8 0%, #e8e8f0 100%);
+    --skin-bg-elevated: rgba(0, 0, 0, 0.06);
+    --skin-border: rgba(0, 0, 0, 0.1);
+    --skin-border-hover: rgba(0, 0, 0, 0.25);
+    --skin-hairline: rgba(0, 0, 0, 0.08);
+
+    --skin-text: #1a1a2e;
+    --skin-text-dim: #606080;
+
+    --skin-accent-text: #7c3aed;
+
+    --skin-fill: rgba(0, 0, 0, 0.06);
+    --skin-fill-hover: rgba(0, 0, 0, 0.12);
+    --skin-track: rgba(0, 0, 0, 0.1);
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     overflow: hidden;
@@ -39,10 +85,10 @@ body {
 .widget-container {
     width: 100vw;
     height: 100vh;
-    background: linear-gradient(135deg, #1e1e2e 0%, #2a2a3e 100%);
+    background: var(--skin-bg);
     overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 10px;
+    border: 1px solid var(--skin-border);
+    border-radius: var(--skin-radius);
     display: flex;
     flex-direction: column;
 }
@@ -50,18 +96,18 @@ body {
 /* Title Bar */
 .title-bar {
     -webkit-app-region: drag;
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--skin-bg-elevated);
     padding: 8px 12px;
     padding-left: 6px;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    border-bottom: 1px solid var(--skin-hairline);
     height: 36px;
 }
 
 .title {
-    color: #e0e0e0;
+    color: var(--skin-text);
     font-family: 'Libre Baskerville', serif;
     font-size: 18px;
     font-weight: 400;
@@ -89,8 +135,8 @@ body {
     width: 28px;
     height: 28px;
     border: none;
-    background: rgba(255, 255, 255, 0.05);
-    color: #a0a0a0;
+    background: var(--skin-fill);
+    color: var(--skin-text-dim);
     border-radius: 6px;
     cursor: pointer;
     display: flex;
@@ -101,8 +147,8 @@ body {
 }
 
 .control-btn:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: #ffffff;
+    background: var(--skin-fill-hover);
+    color: var(--skin-text);
 }
 
 .refresh-btn svg {
@@ -602,7 +648,7 @@ body.theme-light .graph-btn.active {
 */
 
 .usage-label {
-    color: #a0a0a0;
+    color: var(--skin-text-dim);
     font-size: 11px;
     font-weight: 600;
     text-transform: uppercase;
@@ -611,7 +657,7 @@ body.theme-light .graph-btn.active {
 }
 
 .usage-percentage {
-    color: #e0e0e0;
+    color: var(--skin-text);
     font-size: 13px;
     font-weight: 700;
     text-align: right;
@@ -620,7 +666,7 @@ body.theme-light .graph-btn.active {
 /* Progress Bar */
 .progress-bar {
     height: 6px;
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--skin-track);
     border-radius: 3px;
     overflow: hidden;
     margin: 0;
@@ -713,7 +759,7 @@ body.theme-light .graph-btn.active {
 
 .timer-bg {
     fill: none;
-    stroke: rgba(255, 255, 255, 0.1);
+    stroke: var(--skin-track);
     stroke-width: 4;
 }
 
@@ -761,7 +807,7 @@ body.theme-light .graph-btn.active {
 }
 
 .timer-text {
-    color: #e0e0e0;
+    color: var(--skin-text);
     font-size: 12px;
     font-weight: 500;
     font-variant-numeric: tabular-nums;
@@ -899,7 +945,7 @@ body.theme-light .graph-btn.active {
     left: 0;
     width: 100vw;
     height: 100vh;
-    background: linear-gradient(135deg, #1e1e2e 0%, #2a2a3e 100%);
+    background: var(--skin-bg);
     z-index: 1000;
     display: flex;
     align-items: stretch;
@@ -919,10 +965,10 @@ body.theme-light .graph-btn.active {
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(135deg, #1a1a2e 0%, #252535 100%);
+    background: var(--skin-bg);
     display: flex;
     flex-direction: column;
-    border-radius: 10px;
+    border-radius: var(--skin-radius);
     overflow: hidden;
     z-index: 10;
 }
@@ -932,14 +978,14 @@ body.theme-light .graph-btn.active {
     align-items: center;
     justify-content: space-between;
     padding: 8px 12px 8px 14px;
-    background: rgba(0, 0, 0, 0.3);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    background: var(--skin-bg-elevated);
+    border-bottom: 1px solid var(--skin-hairline);
     height: 36px;
     -webkit-app-region: drag;
 }
 
 .settings-title {
-    color: #e0e0e0;
+    color: var(--skin-text);
     font-size: 13px;
     font-weight: 600;
     letter-spacing: 0.3px;
@@ -947,9 +993,9 @@ body.theme-light .graph-btn.active {
 
 .done-settings-btn {
     -webkit-app-region: no-drag;
-    background: rgba(139, 92, 246, 0.2);
-    border: 1px solid rgba(139, 92, 246, 0.4);
-    color: #a78bfa;
+    background: var(--skin-accent-bg);
+    border: 1px solid var(--skin-accent-border);
+    color: var(--skin-accent-text);
     font-size: 11px;
     font-weight: 700;
     padding: 3px 10px;
@@ -961,7 +1007,7 @@ body.theme-light .graph-btn.active {
 .done-settings-btn:hover {
     background: rgba(139, 92, 246, 0.35);
     border-color: rgba(139, 92, 246, 0.7);
-    color: #c4b5fd;
+    color: var(--skin-accent-text);
 }
 
 .settings-disclaimer {
@@ -1150,9 +1196,9 @@ body.theme-light .settings-disclaimer {
 }
 
 .theme-btn {
-    background: rgba(255,255,255,0.06);
-    border: 1px solid rgba(255,255,255,0.12);
-    color: #808080;
+    background: var(--skin-fill);
+    border: 1px solid var(--skin-border);
+    color: var(--skin-text-faint);
     font-size: 10px;
     padding: 3px 8px;
     border-radius: 4px;
@@ -1161,14 +1207,233 @@ body.theme-light .settings-disclaimer {
 }
 
 .theme-btn:hover {
-    color: #c0c0c0;
-    border-color: rgba(255,255,255,0.25);
+    color: var(--skin-text);
+    border-color: var(--skin-border-hover);
 }
 
 .theme-btn.active {
-    background: rgba(139, 92, 246, 0.2);
-    border-color: rgba(139, 92, 246, 0.5);
-    color: #a78bfa;
+    background: var(--skin-accent-bg);
+    border-color: var(--skin-accent-border);
+    color: var(--skin-accent-text);
+}
+
+/* Skin Selector */
+.settings-row-full {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 5px 14px;
+    gap: 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.skin-selector {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.skin-browse-all-btn {
+    background: var(--skin-fill);
+    border: 1px solid var(--skin-border);
+    color: var(--skin-text-dim);
+    font-size: 10px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.skin-browse-all-btn:hover {
+    color: var(--skin-text);
+    border-color: var(--skin-border-hover);
+}
+
+/* ── Skin gallery popup — full preset/custom list, import, AI prompt ────────
+   A plain in-DOM overlay (never touches window size). Sits directly under
+   .widget-container like .settings-overlay, so under the Liquid skin it
+   needs the same position/inset reassertion — see liquid.css. */
+.skin-popup-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 50;
+    display: flex;
+    border-radius: var(--skin-radius);
+    overflow: hidden;
+}
+
+.skin-popup {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background: var(--skin-bg);
+}
+
+.skin-popup-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px 14px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.skin-selector-full {
+    gap: 8px;
+}
+
+.skin-popup-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding-top: 10px;
+    border-top: 1px solid var(--skin-hairline);
+}
+
+/* ── Custom skin import ──────────────────────────────────────────────────── */
+.skin-import {
+    width: 100%;
+}
+
+.skin-import-toggle-btn,
+.skin-import-submit-btn,
+.skin-import-cancel-btn {
+    background: var(--skin-fill);
+    border: 1px solid var(--skin-border);
+    color: var(--skin-text-dim);
+    font-size: 10px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.skin-import-toggle-btn:hover,
+.skin-import-cancel-btn:hover {
+    color: var(--skin-text);
+    border-color: var(--skin-border-hover);
+}
+
+.skin-import-submit-btn {
+    background: var(--skin-accent-bg);
+    border-color: var(--skin-accent-border);
+    color: var(--skin-accent-text);
+}
+
+.skin-import-submit-btn:hover {
+    box-shadow: 0 0 8px var(--skin-accent-bg);
+}
+
+.skin-import-form {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.skin-import-textarea {
+    width: 100%;
+    resize: vertical;
+    min-height: 64px;
+    background: var(--skin-fill);
+    border: 1px solid var(--skin-border);
+    color: var(--skin-text);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 10px;
+    padding: 6px 8px;
+    border-radius: 6px;
+}
+
+.skin-import-textarea:focus {
+    border-color: var(--skin-accent-border);
+}
+
+.skin-import-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.skin-import-error {
+    color: #ff7a7a;
+    font-size: 10px;
+    line-height: 1.3;
+    min-height: 0;
+}
+
+.skin-import-error:empty {
+    display: none;
+}
+
+.skin-preview-custom-delete {
+    background: transparent;
+    border: none;
+    color: var(--skin-text-faint);
+    cursor: pointer;
+    font-size: 11px;
+    padding: 0 2px;
+    line-height: 1;
+}
+
+.skin-preview-custom-delete:hover {
+    color: #ff7a7a;
+}
+
+.skin-btn {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    background: var(--skin-fill);
+    border: 1px solid var(--skin-border);
+    border-radius: 6px;
+    padding: 3px 8px 3px 5px;
+    cursor: pointer;
+    transition: all 0.2s;
+    color: #808080;
+    font-size: 10px;
+}
+
+.skin-btn:hover {
+    border-color: var(--skin-border-hover);
+    color: var(--skin-text);
+}
+
+.skin-btn.active {
+    background: var(--skin-accent-bg);
+    border-color: var(--skin-accent-border);
+    color: var(--skin-accent-text);
+}
+
+.skin-preview {
+    width: 16px;
+    height: 16px;
+    border-radius: 3px;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.skin-preview-none {
+    background: linear-gradient(135deg, #1e1e2e 0%, #2a2a3e 100%);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.skin-preview-liquid {
+    background: linear-gradient(
+        135deg,
+        rgba(124, 58, 237, 0.9) 0%,
+        rgba(59, 130, 246, 0.7) 40%,
+        rgba(20, 184, 166, 0.8) 100%
+    );
+    border: 1px solid rgba(139, 92, 246, 0.35);
+    animation: skin-preview-shimmer 3s ease-in-out infinite alternate;
+}
+
+@keyframes skin-preview-shimmer {
+    0%   { filter: brightness(0.85) saturate(1.0); }
+    100% { filter: brightness(1.15) saturate(1.3); }
 }
 
 /* Settings Footer */
@@ -1290,73 +1555,18 @@ body.theme-light .settings-disclaimer {
     stroke: #10b981;
 }
 
-/* Light Theme */
-body.theme-light .widget-container {
-    background: linear-gradient(135deg, #f0f0f8 0%, #e8e8f0 100%);
-    border-color: rgba(0, 0, 0, 0.1);
-}
-
-body.theme-light .title-bar,
-body.theme-light .settings-header {
-    background: rgba(0, 0, 0, 0.06);
-    border-bottom-color: rgba(0, 0, 0, 0.08);
-}
-
-body.theme-light .title,
-body.theme-light .settings-title {
-    color: #1a1a2e;
-}
-
-body.theme-light .usage-label {
-    color: #606080;
-}
-
-body.theme-light .usage-percentage,
-body.theme-light .timer-text {
-    color: #1a1a2e;
-}
-
-body.theme-light .progress-bar {
-    background: rgba(0, 0, 0, 0.1);
-}
-
-body.theme-light .timer-bg {
-    stroke: rgba(0, 0, 0, 0.1);
-}
-
-body.theme-light .control-btn {
-    background: rgba(0, 0, 0, 0.06);
-    color: #505070;
-}
-
-body.theme-light .control-btn:hover {
-    background: rgba(0, 0, 0, 0.12);
-    color: #1a1a2e;
-}
-
-body.theme-light .settings-overlay {
-    background: linear-gradient(135deg, #f0f0f8 0%, #e8e8f0 100%);
-    border-radius: 10px;
-}
-
+/* Light Theme
+   NOTE: widget-container/title-bar/settings-header/title/settings-title/
+   usage-label/usage-percentage/timer-text/progress-bar/timer-bg/control-btn/
+   settings-overlay/theme-btn now retheme automatically via the --skin-*
+   token contract's `body.theme-light` overrides above — no per-selector
+   override needed here anymore. */
 body.theme-light .settings-row-label {
     color: #303050;
 }
 
 body.theme-light .settings-disclaimer {
     color: #9090a0;
-}
-
-body.theme-light .theme-btn {
-    background: rgba(0,0,0,0.06);
-    border-color: rgba(0,0,0,0.12);
-    color: #606080;
-}
-
-body.theme-light .theme-btn.active {
-    background: rgba(139, 92, 246, 0.15);
-    border-color: rgba(139, 92, 246, 0.4);
-    color: #7c3aed;
 }
 
 body.theme-light .expand-section {

--- a/src/skin-validator.js
+++ b/src/skin-validator.js
@@ -1,0 +1,133 @@
+// Skin validator — shared by main.js (custom-skin import) and
+// scripts/validate-skins.js (build-time preset check). Plain CommonJS,
+// no dependencies, safe to require from either Node context.
+//
+// A skin is JSON: { id, name, author?, description?, tokens: {...}, advanced? }
+// `tokens` may only contain keys from KNOWN_TOKENS (the standardized --skin-*
+// contract — see src/renderer/skins/CREATING_A_SKIN.md) and values that pass
+// an allow-list format check. `advanced` (a bundled CSS filename for extra
+// pseudo-element effects) is only permitted for built-in presets, never for
+// user-imported custom skins.
+
+const KNOWN_TOKENS = [
+  '--skin-bg',
+  '--skin-bg-elevated',
+  '--skin-border',
+  '--skin-border-hover',
+  '--skin-hairline',
+  '--skin-radius',
+  '--skin-text',
+  '--skin-text-dim',
+  '--skin-text-faint',
+  '--skin-accent',
+  '--skin-accent-bg',
+  '--skin-accent-border',
+  '--skin-accent-text',
+  '--skin-fill',
+  '--skin-fill-hover',
+  '--skin-track',
+];
+
+// A skin doesn't need to set every token (unset ones inherit the "None"
+// skin's defaults), but it must set enough to actually look like a skin.
+const REQUIRED_TOKENS = ['--skin-bg', '--skin-text', '--skin-accent'];
+
+const RADIUS_TOKENS = new Set(['--skin-radius']);
+
+// Only characters that can legitimately appear in a CSS color/gradient
+// function chain — blocks `url(`, `;`, `{`, `}`, `<`, backslashes, etc. by
+// construction, independent of the substring deny-list below.
+const COLOR_CHARSET = /^[a-zA-Z0-9#(),.%\-+ ]+$/;
+const LENGTH_VALUE = /^\d+(\.\d+)?(px|%)?$/;
+const DENY_SUBSTRINGS = ['url(', 'expression(', '@import', 'javascript:', '<', '\\'];
+
+const ID_FORMAT = /^[a-z0-9][a-z0-9-]{1,40}$/;
+const TOP_LEVEL_FIELDS_BUILTIN = new Set(['id', 'name', 'author', 'description', 'tokens', 'advanced']);
+const TOP_LEVEL_FIELDS_CUSTOM = new Set(['id', 'name', 'author', 'description', 'tokens']);
+
+function isPlainString(v, maxLen) {
+  return typeof v === 'string' && v.length > 0 && v.length <= maxLen && !/[\x00-\x1f]/.test(v);
+}
+
+function validateTokenValue(name, value) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 300) {
+    return `${name}: value must be a non-empty string (max 300 chars)`;
+  }
+  for (const bad of DENY_SUBSTRINGS) {
+    if (value.toLowerCase().includes(bad)) {
+      return `${name}: value contains disallowed content ("${bad}")`;
+    }
+  }
+  if (RADIUS_TOKENS.has(name)) {
+    if (!LENGTH_VALUE.test(value.trim())) {
+      return `${name}: expected a length like "10px" or "22", got "${value}"`;
+    }
+    return null;
+  }
+  if (!COLOR_CHARSET.test(value)) {
+    return `${name}: value contains characters not allowed in a color/gradient (got "${value}")`;
+  }
+  return null;
+}
+
+/**
+ * @param {object} skin - parsed skin JSON
+ * @param {{context: 'builtin'|'custom'}} opts
+ * @returns {{valid: boolean, errors: string[]}}
+ */
+function validateSkin(skin, opts = {}) {
+  const context = opts.context === 'builtin' ? 'builtin' : 'custom';
+  const errors = [];
+
+  if (!skin || typeof skin !== 'object' || Array.isArray(skin)) {
+    return { valid: false, errors: ['skin must be a JSON object'] };
+  }
+
+  const allowedFields = context === 'builtin' ? TOP_LEVEL_FIELDS_BUILTIN : TOP_LEVEL_FIELDS_CUSTOM;
+  for (const key of Object.keys(skin)) {
+    if (!allowedFields.has(key)) {
+      errors.push(`unknown top-level field "${key}"${key === 'advanced' ? ' (advanced is built-in-only)' : ''}`);
+    }
+  }
+
+  if (!isPlainString(skin.id, 42) || !ID_FORMAT.test(skin.id)) {
+    errors.push('id must be a lowercase-alphanumeric-with-hyphens slug, 2-42 chars');
+  }
+  if (!isPlainString(skin.name, 40)) {
+    errors.push('name must be a non-empty string, max 40 chars');
+  }
+  if (skin.author !== undefined && !isPlainString(skin.author, 40)) {
+    errors.push('author must be a string, max 40 chars');
+  }
+  if (skin.description !== undefined && !isPlainString(skin.description, 200)) {
+    errors.push('description must be a string, max 200 chars');
+  }
+
+  if (!skin.tokens || typeof skin.tokens !== 'object' || Array.isArray(skin.tokens)) {
+    errors.push('tokens must be an object');
+  } else {
+    for (const [name, value] of Object.entries(skin.tokens)) {
+      if (!KNOWN_TOKENS.includes(name)) {
+        errors.push(`unknown token "${name}" — must be one of the standardized --skin-* tokens`);
+        continue;
+      }
+      const err = validateTokenValue(name, value);
+      if (err) errors.push(err);
+    }
+    for (const required of REQUIRED_TOKENS) {
+      if (!(required in skin.tokens)) {
+        errors.push(`missing required token "${required}"`);
+      }
+    }
+  }
+
+  if (context === 'builtin' && skin.advanced !== undefined) {
+    if (!isPlainString(skin.advanced, 80) || !/^[a-zA-Z0-9_-]+\.css$/.test(skin.advanced)) {
+      errors.push('advanced must be a plain "<name>.css" filename');
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+module.exports = { validateSkin, KNOWN_TOKENS, REQUIRED_TOKENS };


### PR DESCRIPTION
## What this adds

- A standardized 16-property `--skin-*` CSS custom-property contract that any skin sets to retheme the app's chrome (title bar, buttons, settings panel), without touching the semantic usage-bar colors.
- 10 built-in presets: Liquid (carried over), Midnight OLED, Sunset, Forest, Monochrome, High Contrast, Retro Terminal, Pastel, Cyberpunk Neon, Corporate Slate.
- A settings UI showing a featured row (None, Liquid, Midnight OLED, plus whatever's active) with a "Browse all skins..." popup for the rest, reusing the existing settings-overlay visual pattern.
- A custom-skin import path: paste a `skin.json`, it's validated (tokens only, never raw CSS) and persisted.
- A "Copy AI prompt" button that copies `CREATING_A_SKIN.md`'s full spec to the clipboard, so you can paste it into your own Claude session, design your own custom `skin.json`, and import it.

## Why

Two presets have a concrete, non-decorative justification: **High Contrast** (legibility) and **Midnight OLED** (true-black power/eye-strain reduction on an always-on tray element). The rest, and the whole import/AI-authoring path, is a bet, not a response to a filed issue or user request: small always-visible status tools are one of the most consistently themed categories of software that exists (terminal color schemes, VS Code themes, Winamp/Rainmeter skins), and this is a wager that the same holds here. `src/renderer/skins/RATIONALE.md` says this explicitly and names what would justify keeping the import path (real usage) versus cutting it (a few months of nobody touching it).

## Security

Custom skins are JSON, never CSS. `src/skin-validator.js` enforces an allowlist-first charset check on every token value (not a denylist you can slip past, plus a substring denylist as defense in depth), a strict allowlist on top-level fields and token names, and `advanced` (bundled CSS) is builtin-only, never allowed on an imported skin. Tokens apply via `element.style.setProperty()`, never string-built into a stylesheet. `main.js`'s IPC handler re-validates every import independently of the renderer's own check, and again on every read from disk. A committed adversarial regression suite (21 cases: injection/bypass payloads, prototype pollution, malformed shapes, a ReDoS timing guard) runs on every `predev`/`prestart`/`prebuild*`, not just once in review. This isn't scoped to self-authored skins either: the app is single-user today, but validation applies the same way regardless of who wrote the `skin.json`, so one passed along from someone else, or found online, gets no more trust than one you made yourself, it either passes the same checks or gets rejected.

## Isolation

Opt-in and isolated. Users who never touch skins see no behavior change. The feature is confined to `src/renderer/skins/`, `src/skin-validator.js`, `scripts/validate-skins.js`, and 3 IPC handlers, it never touches usage-fetching, auth, or the tray icon.

## Commit structure

Split into two commits on purpose: token system + presets (stays regardless), then picker UI + custom import (a bet, per `RATIONALE.md`, structured so a future revert of it alone cleanly removes it without touching the system underneath).
