### PR TITLE
fix: don't crash on Linux/Wayland when run as a mounted AppImage

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,48 +1,44 @@
 const { app, BrowserWindow, ipcMain, Tray, Menu, session, shell, Notification, safeStorage, nativeImage, screen } = require('electron');
 
-// Linux/Wayland: force Xwayland compatibility mode so the second system tray
-// icon (weekly) actually renders (Issue #119). Electron's Tray backend only
-// gives the *first* Tray() instance in a process real StatusNotifierItem
-// (SNI) support; every subsequent instance falls back to the older
-// GtkStatusIcon protocol (documented at
-// https://www.electronjs.org/docs/latest/api/tray). GtkStatusIcon has no
-// working implementation under native Wayland — it depends on X11 window-
-// server semantics Wayland doesn't provide — so it silently fails to appear.
-// Electron 38 changed the *default* from Xwayland compat mode to native
-// Wayland, which is what exposed this: earlier versions quietly ran every
-// session through Xwayland regardless of the actual session type, so the
-// GtkStatusIcon fallback always had something to attach to. This isn't
-// undoing a regression in the traditional sense — the fallback's Wayland gap
-// always existed, Electron 38 just stopped papering over it by default.
-//
-// Implemented as a one-time self-relaunch, NOT app.commandLine.appendSwitch().
-// appendSwitch() was tried first and shipped briefly — it's technically the
-// first executable statement in this file, but that's still too late:
-// Chromium's native Ozone/platform-backend selection happens in C++ before
-// Electron hands control to this script at all, so appendSwitch() landed in
-// a broken half-X11/half-Wayland hybrid state (confirmed live: XGetWindow-
-// Attributes failures, zero tray icons, worse than the original bug) rather
-// than genuinely forcing Xwayland. A real command-line argument, present in
-// argv from process start, IS parsed early enough — hence relaunching once
-// with the flag baked into the new process's actual argv. The argv guard
-// below prevents relaunching forever once that flag is already present.
-// Confirmed working live on a real Fedora 44 KDE Plasma Wayland session:
-// clean single relaunch, both tray icons render, busctl confirms both
-// registered.
-//
-// Only on Linux/Wayland — X11 sessions, Windows, and macOS are unaffected
-// and untouched. Confirmed via manual Electron version bisection: 37.10.3
-// unaffected, 38.8.6+ affected; this relaunch-with-flag approach confirmed
-// to resolve it on 41.x (the range this app currently installs, per
-// package.json's ^41.10.1). Not yet effective as of Electron 43.x in ad hoc
-// testing — root cause for that not yet identified, and out of scope today
-// since npm's caret range on our pin can't install past 41.x without a
-// deliberate package.json change. If a future Electron bump changes the
-// installed major version, re-verify the second tray icon manually on
-// Linux/Wayland before shipping.
-if (process.platform === 'linux' && process.env.XDG_SESSION_TYPE === 'wayland' && !process.argv.includes('--ozone-platform=x11')) {
-  app.relaunch({ args: process.argv.slice(1).concat(['--ozone-platform=x11']) });
-  app.exit(0);
+// Linux/Wayland: force Xwayland compat mode so the second system tray icon
+// (weekly) renders — Electron only gives the *first* Tray() instance real
+// StatusNotifierItem support; later ones fall back to GtkStatusIcon, which
+// doesn't work under native Wayland (Issue #119). Done via a one-time
+// self-relaunch with a real argv flag, not app.commandLine.appendSwitch()
+// — Chromium picks its Ozone backend before appendSwitch() would take
+// effect. Linux/Wayland only; X11, Windows, and macOS are untouched.
+relaunchUnderXwaylandIfNeeded();
+
+function relaunchUnderXwaylandIfNeeded() {
+  const flag = '--ozone-platform=x11';
+  if (process.platform !== 'linux' || process.env.XDG_SESSION_TYPE !== 'wayland' || process.argv.includes(flag)) {
+    return;
+  }
+
+  const relaunchArgs = process.argv.slice(1).concat([flag]);
+
+  if (process.env.APPIMAGE) {
+    // app.relaunch() can't be used here: it spawns an intermediate
+    // "relauncher" helper off the *current* (mounted) binary, which blocks
+    // waiting for this process to exit — but this process exiting is what
+    // unmounts the binary the helper is still running from, killing it
+    // before it ever launches the real target. Spawning process.env.APPIMAGE
+    // (the original .appimage file) ourselves sidesteps that entirely; it
+    // gets its own independent mount. Trade-off: this process's own AppImage
+    // mount can't fully unmount until the relaunched instance exits (it
+    // inherits a few fds into it), so a harmless idle process+mount lingers
+    // for the session's lifetime and cleans up on quit.
+    const { spawn } = require('child_process');
+    const child = spawn(process.env.APPIMAGE, relaunchArgs, { detached: true, stdio: 'ignore' });
+    child.once('spawn', () => {
+      child.unref();
+      app.exit(0);
+    });
+    child.once('error', () => app.exit(0));
+  } else {
+    app.relaunch({ args: relaunchArgs });
+    app.exit(0);
+  }
 }
 
 const path = require('path');


### PR DESCRIPTION
## Summary
The Issue #119 Xwayland-tray fix (`fix/linux-wayland-second-tray-icon`, `fix/wayland-tray-relaunch-instead-of-switch`) self-relaunches via `app.relaunch()` + `app.exit(0)` on Linux/Wayland. Run as the actual AppImage artifact (not `npm start`, not the extracted binary), this crashes on *every* launch, before any window appears — no error output, no window, just a silent return to the shell (or a "Cannot mount AppImage" / crash dialog depending on timing).

## Root cause
`app.relaunch()` isn't a single spawn — per Electron's own source (`shell/browser/relauncher.cc`, `relauncher_linux.cc`), it spawns an intermediate "relauncher" helper process off `content::CHILD_PROCESS_EXE` (i.e. `process.execPath`, the *currently running* binary), which sets `PR_SET_PDEATHSIG` and blocks waiting for this process to exit before it launches the real target.

Run as a mounted AppImage, that's fatal: this process exiting is exactly what causes the AppImage runtime to unmount the binary the helper is still running from — killing the helper before it ever reaches the point of launching anything. No `execPath`/`args` combination passed to `app.relaunch()` avoids this, since the helper stage itself always uses the current binary, regardless of what target we ask it to relaunch into.

Confirmed via:
- Electron's own `relauncher.cc`/`relauncher_linux.cc` source (v41.10.1)
- `coredumpctl` (SIGBUS/SIGTRAP on the relaunched process, executable path showing as unlinked)
- Live mount-timing capture (original mount present, vanishes at `app.exit(0)`, no second mount ever appears)

## Fix
When `process.env.APPIMAGE` is set (i.e. running as a mounted AppImage — set by the AppImage runtime itself, points at the original `.appimage` file), bypass `app.relaunch()` entirely and spawn `process.env.APPIMAGE` ourselves via `child_process.spawn({ detached: true })`, only calling `app.exit(0)` once the child has actually started (`'spawn'` event). The new process gets its own independent FUSE mount, decoupled from this process's lifetime.

Non-AppImage Linux/Wayland installs (`.deb`, extracted dir, etc.) are unaffected and keep using `app.relaunch()` as before.

## Known trade-off (not fixed here)
This process's own AppImage mount can't fully unmount until the relaunched instance exits — it inherits a few file descriptors into it via `fork()` (confirmed via `lsof`: `icudtl.dat`, `v8_context_snapshot.bin`, `resources/app.asar`), since Node's `child_process.spawn()` has no `close_fds`-equivalent option. This leaves one harmless, idle process + mount for the session's lifetime, which fully cleans up on quit. No functional impact — verified both tray icons still render correctly, app fully usable throughout.

## Testing
- Reproduced the crash on a real Fedora 44 KDE Plasma Wayland session, both from the pre-built `1.7.7-rc.1` AppImage and a from-source rebuild
- Confirmed root cause against Electron 41.10.1's actual source
- Applied fix, rebuilt (`electron-builder --linux AppImage --x64`), confirmed: no crash, both tray icons render (session + weekly), app fully functional
- Confirmed mount/process cleanup on quit via `lsof`/`mount`