### PR TITLE
Window-position fixes: move-save crash guard + clamp-to-display recovery

### DIFF
--- a/main.js
+++ b/main.js
@@ -506,6 +506,11 @@ function createMainWindow() {
   mainWindow.on('move', () => {
     if (positionSaveTimer) clearTimeout(positionSaveTimer);
     positionSaveTimer = setTimeout(() => {
+      // The window can be destroyed between the move and this debounce
+      // firing (close/quit within 300ms of a drag) — getBounds on a
+      // destroyed window throws. The sibling 'resize' handler already
+      // guards; 'move' was missed.
+      if (!mainWindow || mainWindow.isDestroyed()) return;
       const position = mainWindow.getBounds();
       store.set('windowPosition', { x: position.x, y: position.y });
     }, 300);

--- a/main.js
+++ b/main.js
@@ -46,6 +46,7 @@ const https = require('https');
 const Store = require('electron-store');
 const { fetchViaWindow, fetchMultipleViaWindow } = require('./src/fetch-via-window');
 const { normalizeUsageLimits } = require('./src/normalize-usage-limits');
+const { recoverBounds, clearsVisibilityThreshold } = require('./src/window-bounds');
 const { detectActiveCreditSpend } = require('./src/detect-active-credit-spend');
 
 const GITHUB_OWNER = 'SlavomirDurej';
@@ -425,6 +426,13 @@ function isPositionOnScreen(x, y, width, height) {
   });
 }
 
+// Displays ordered primary-first — recoverBounds treats the first entry as
+// the primary for its recenter fallback.
+function orderedDisplays() {
+  const primary = screen.getPrimaryDisplay();
+  return [primary, ...screen.getAllDisplays().filter((d) => d.id !== primary.id)];
+}
+
 // Centered position on the primary display's work area, for the given window size.
 function getCenteredPosition(width, height) {
   const area = screen.getPrimaryDisplay().workArea;
@@ -441,8 +449,12 @@ function getCenteredPosition(width, height) {
 function isMainWindowShownOnScreen() {
   if (!mainWindow || mainWindow.isDestroyed()) return false;
   if (!mainWindow.isVisible() || mainWindow.isMinimized()) return false;
+  // Same 80x32 threshold recoverBounds uses, so the tray toggle and every
+  // recovery path agree on what "shown" means — an any-pixel-overlap check
+  // here called a sliver-visible window "shown" and hid it on tray click.
   const bounds = mainWindow.getBounds();
-  return isPositionOnScreen(bounds.x, bounds.y, bounds.width, bounds.height);
+  return orderedDisplays().some((display) =>
+    clearsVisibilityThreshold(bounds, display.workArea || display.bounds, 80, 32));
 }
 
 // Implicit/automatic triggers (tray left-click, taskbar left-click/restore,
@@ -461,11 +473,15 @@ function showMainWindowSmart() {
     return;
   }
   const bounds = mainWindow.getBounds();
-  if (!isPositionOnScreen(bounds.x, bounds.y, bounds.width, bounds.height)) {
-    const { x, y } = getCenteredPosition(bounds.width, bounds.height);
-    debugLog('[Window] Recentering off-screen window from', bounds, 'to', { x, y });
-    mainWindow.setPosition(x, y);
-    store.set('windowPosition', { x, y });
+  const recovered = recoverBounds(bounds, orderedDisplays(), {
+    fallbackWidth: WIDGET_WIDTH,
+    fallbackHeight: WIDGET_HEIGHT
+  });
+  if (recovered.x !== bounds.x || recovered.y !== bounds.y
+      || recovered.width !== bounds.width || recovered.height !== bounds.height) {
+    debugLog('[Window] Recovering window from', bounds, 'to', recovered);
+    mainWindow.setBounds(recovered);
+    store.set('windowPosition', { x: recovered.x, y: recovered.y });
   }
   if (mainWindow.isMinimized()) mainWindow.restore();
   mainWindow.show();
@@ -474,9 +490,16 @@ function showMainWindowSmart() {
 
 function createMainWindow() {
   let savedPosition = store.get('windowPosition');
-  if (savedPosition && !isPositionOnScreen(savedPosition.x, savedPosition.y, WIDGET_WIDTH, WIDGET_HEIGHT)) {
-    debugLog('[Window] Saved position', savedPosition, 'is off-screen on current display setup; centering instead');
-    savedPosition = null;
+  if (savedPosition) {
+    const recovered = recoverBounds(
+      { x: savedPosition.x, y: savedPosition.y, width: WIDGET_WIDTH, height: WIDGET_HEIGHT },
+      orderedDisplays(),
+      { fallbackWidth: WIDGET_WIDTH, fallbackHeight: WIDGET_HEIGHT }
+    );
+    if (recovered.x !== savedPosition.x || recovered.y !== savedPosition.y) {
+      debugLog('[Window] Saved position', savedPosition, 'recovered to', recovered);
+    }
+    savedPosition = { x: recovered.x, y: recovered.y };
   }
   const windowOptions = {
     width: WIDGET_WIDTH,

--- a/src/window-bounds.js
+++ b/src/window-bounds.js
@@ -1,0 +1,103 @@
+'use strict';
+
+function normalizeBounds(bounds, fallback) {
+  const source = bounds || {};
+  const base = fallback || {};
+  const numberOr = (value, fallbackValue) => Number.isFinite(value) ? value : fallbackValue;
+  return {
+    x: numberOr(source.x, base.x),
+    y: numberOr(source.y, base.y),
+    width: numberOr(source.width, base.width),
+    height: numberOr(source.height, base.height)
+  };
+}
+
+function intersects(a, b) {
+  return a.x < b.x + b.width
+    && a.x + a.width > b.x
+    && a.y < b.y + b.height
+    && a.y + a.height > b.y;
+}
+
+function visibleArea(rect, area) {
+  const left = Math.max(rect.x, area.x);
+  const top = Math.max(rect.y, area.y);
+  const right = Math.min(rect.x + rect.width, area.x + area.width);
+  const bottom = Math.min(rect.y + rect.height, area.y + area.height);
+  return { width: Math.max(0, right - left), height: Math.max(0, bottom - top) };
+}
+
+// A display "counts" only when it shows a substantial piece of the window.
+// The same threshold gates every branch of recoverBounds, so a 1px sliver
+// neither pins a window in place nor claims it for a display.
+function clearsVisibilityThreshold(rect, area, minVisibleWidth, minVisibleHeight) {
+  if (!intersects(rect, area)) return false;
+  const visible = visibleArea(rect, area);
+  return visible.width >= Math.min(minVisibleWidth, rect.width)
+      && visible.height >= Math.min(minVisibleHeight, rect.height);
+}
+
+function clampIntoDisplay(rect, area) {
+  const width = Math.min(rect.width, area.width);
+  const height = Math.min(rect.height, area.height);
+  return {
+    width,
+    height,
+    x: Math.min(Math.max(rect.x, area.x), area.x + area.width - width),
+    y: Math.min(Math.max(rect.y, area.y), area.y + area.height - height)
+  };
+}
+
+// Window-position recovery, three testable rules against one visibility
+// threshold (default 80x32):
+//   2+ displays clear it  -> straddling monitors: snap fully onto whichever
+//                            shows more of the window.
+//   exactly 1 clears it   -> substantially visible somewhere: leave it
+//                            exactly where the user put it (hanging off a
+//                            single display's edge is a choice, and the OS
+//                            already offers snapping for people who want it).
+//   0 clear it            -> not meaningfully visible anywhere (sliver-only
+//                            included): recenter on the primary display.
+function recoverBounds(bounds, displays, {
+  fallbackWidth = 560,
+  fallbackHeight = 400,
+  minVisibleWidth = 80,
+  minVisibleHeight = 32
+} = {}) {
+  const workAreas = (displays || [])
+    .map((d) => d && (d.workArea || d.bounds))
+    .filter((a) => a && [a.x, a.y, a.width, a.height].every(Number.isFinite));
+
+  if (!workAreas.length) {
+    return { x: 0, y: 0, width: fallbackWidth, height: fallbackHeight };
+  }
+
+  const normalized = normalizeBounds(bounds, {
+    x: workAreas[0].x, y: workAreas[0].y, width: fallbackWidth, height: fallbackHeight
+  });
+
+  const matches = workAreas.filter((area) =>
+    clearsVisibilityThreshold(normalized, area, minVisibleWidth, minVisibleHeight)
+  );
+
+  if (matches.length >= 2) {
+    const best = matches.reduce((a, b) =>
+      visibleArea(normalized, b).width * visibleArea(normalized, b).height
+        > visibleArea(normalized, a).width * visibleArea(normalized, a).height ? b : a
+    );
+    return clampIntoDisplay(normalized, best);
+  }
+
+  if (matches.length === 1) {
+    return normalized;
+  }
+
+  const primary = workAreas[0];
+  return {
+    ...normalized,
+    x: Math.round(primary.x + (primary.width - normalized.width) / 2),
+    y: Math.round(primary.y + (primary.height - normalized.height) / 2)
+  };
+}
+
+module.exports = { normalizeBounds, intersects, visibleArea, clearsVisibilityThreshold, clampIntoDisplay, recoverBounds };

--- a/test/window-bounds.test.js
+++ b/test/window-bounds.test.js
@@ -1,0 +1,56 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { normalizeBounds, visibleArea, clearsVisibilityThreshold, recoverBounds } = require('../src/window-bounds');
+
+const MAIN = { workArea: { x: 0, y: 0, width: 1920, height: 1080 } };
+const SIDE = { workArea: { x: 1920, y: 0, width: 1280, height: 1024 } };
+
+test('straddling two displays snaps fully onto the one showing more', () => {
+  // 560 wide at x=1520: 400px on MAIN, 160px on SIDE — both clear 80x32
+  const out = recoverBounds({ x: 1520, y: 100, width: 560, height: 400 }, [MAIN, SIDE]);
+  assert.equal(out.x + out.width <= 1920, true, 'fully inside MAIN');
+  assert.equal(out.x >= 0, true);
+  assert.deepEqual({ w: out.width, h: out.height }, { w: 560, h: 400 });
+});
+
+test('hanging off a single display is left exactly alone', () => {
+  // 300px visible on MAIN, the rest off the left edge into empty space
+  const bounds = { x: -260, y: 100, width: 560, height: 400 };
+  const out = recoverBounds(bounds, [MAIN, SIDE]);
+  assert.deepEqual(out, bounds);
+});
+
+test('sliver-only visibility recenters on primary', () => {
+  // 10px visible on MAIN — below the 80px threshold everywhere
+  const out = recoverBounds({ x: -550, y: 100, width: 560, height: 400 }, [MAIN, SIDE]);
+  assert.equal(out.x, Math.round((1920 - 560) / 2));
+  assert.equal(out.y, Math.round((1080 - 400) / 2));
+});
+
+test('fully off-screen recenters on primary', () => {
+  const out = recoverBounds({ x: 5000, y: 5000, width: 560, height: 400 }, [MAIN, SIDE]);
+  assert.equal(out.x, Math.round((1920 - 560) / 2));
+});
+
+test('no displays falls back to origin at fallback size', () => {
+  assert.deepEqual(recoverBounds({ x: 5, y: 5, width: 300, height: 200 }, []),
+    { x: 0, y: 0, width: 560, height: 400 });
+});
+
+test('threshold shrinks for windows smaller than it', () => {
+  // a 40x20 window fully visible clears the (min(80,40) x min(32,20)) gate
+  const bounds = { x: 10, y: 10, width: 40, height: 20 };
+  assert.equal(clearsVisibilityThreshold(bounds, MAIN.workArea, 80, 32), true);
+  assert.deepEqual(recoverBounds(bounds, [MAIN]), bounds);
+});
+
+test('normalizeBounds fills holes from the fallback', () => {
+  assert.deepEqual(normalizeBounds({ x: 3 }, { x: 1, y: 2, width: 30, height: 40 }),
+    { x: 3, y: 2, width: 30, height: 40 });
+});
+
+test('visibleArea clips to the intersection', () => {
+  assert.deepEqual(visibleArea({ x: -100, y: 0, width: 300, height: 50 }, MAIN.workArea),
+    { width: 200, height: 50 });
+});


### PR DESCRIPTION
Two related window-position fixes, in separate commits so you can take either independently (feel free to cherry-pick just one).

## 1. `fix: guard debounced move-save against a destroyed window`

The 300 ms position-save debounce in the `move` handler can fire after the window has been closed (drag the window, then close/quit within the debounce window). `getBounds()` on a destroyed `BrowserWindow` then throws:

```
TypeError: Cannot read properties of null (reading 'getBounds')
```

The sibling `resize` handler already guards against this; `move` was missed. One-line guard.

## 2. `feat: clamp off-screen windows to the nearest display instead of recentering`

Builds on the off-screen recovery you shipped in 1.7.6 (#94). Both recovery paths currently treat off-screen as all-or-nothing: any position failing `isPositionOnScreen` is discarded and the window recenters on the primary display. That loses the user's chosen spot in the *partial* cases, which are the common ones:

- a window half-dragged off an edge,
- a display that shrank (resolution change),
- a dock/undock that shifted the monitor arrangement.

This PR adds `src/window-bounds.js` — a small pure module with unit tests (`node --test`) — whose `clampBoundsToDisplays()` snaps saved bounds to the nearest live display edge instead, requiring a minimum visible area (80×32 px) so a sliver peeking in from a corner still counts as unreachable. It also clamps the window's *size* to the hosting display's work area, which recovers windows saved larger than the display they now land on. Fully unreachable positions still fall back to primary-centered, same as today.

Both `createMainWindow`'s startup restore and `showMainWindowSmart` route through it; `isPositionOnScreen` stays for `isMainWindowShownOnScreen`.

We've been running this clamp in our fork ([imburning](https://github.com/dev-newb/imburning-electron)) across dock/undock cycles on macOS with an external-monitor setup; the move-guard crash is one we hit in practice.