### PR TITLE
feat: show profile name in title bar and tray tooltips

### DIFF
--- a/main.js
+++ b/main.js
@@ -1190,11 +1190,11 @@ function createTray() {
     
     // Create Weekly tray icon FIRST (left position, blue)
     weeklyTray = new Tray(staticIconPath);
-    weeklyTray.setToolTip('Weekly Usage');
-    
+    weeklyTray.setToolTip(profileName ? `Weekly Usage — ${profileName}` : 'Weekly Usage');
+
     // Create Session tray icon SECOND (right position, purple)
     sessionTray = new Tray(staticIconPath);
-    sessionTray.setToolTip('Session Usage');
+    sessionTray.setToolTip(profileName ? `Session Usage — ${profileName}` : 'Session Usage');
 
     logger.log('Tray created (session + weekly icons)');
 
@@ -1399,7 +1399,7 @@ function updateTrayIcon(usageData) {
     }
     if (weeklyTray && !weeklyTray.isDestroyed()) {
       weeklyTray.setImage(weeklyIcon);
-      let weeklyTooltip = `Weekly: ${Math.round(weeklyPercent)}%`;
+      let weeklyTooltip = profileName ? `${profileName} — Weekly: ${Math.round(weeklyPercent)}%` : `Weekly: ${Math.round(weeklyPercent)}%`;
       const weeklyResetTime = formatResetTime(weeklyResetsAt, timeFormat, true);
       if (weeklyResetTime) {
         weeklyTooltip += `\nResets: ${weeklyResetTime}`;
@@ -1417,7 +1417,7 @@ function updateTrayIcon(usageData) {
     }
     if (sessionTray && !sessionTray.isDestroyed()) {
       sessionTray.setImage(sessionIcon);
-      let sessionTooltip = `Session: ${Math.round(sessionPercent)}%`;
+      let sessionTooltip = profileName ? `${profileName} — Session: ${Math.round(sessionPercent)}%` : `Session: ${Math.round(sessionPercent)}%`;
       const sessionResetTime = formatResetTime(sessionResetsAt, timeFormat, false);
       if (sessionResetTime) {
         sessionTooltip += `\nResets: ${sessionResetTime}`;
@@ -1468,6 +1468,8 @@ function getStoredSessionKey(context = '') {
 }
 
 // IPC Handlers
+ipcMain.handle('get-profile-name', () => profileName);
+
 ipcMain.handle('get-credentials', () => {
   return {
     sessionKey: getStoredSessionKey(),

--- a/preload.js
+++ b/preload.js
@@ -20,6 +20,9 @@ function isAllowedExternalUrl(url) {
 }
 
 contextBridge.exposeInMainWorld('electronAPI', {
+  // Profile
+  getProfileName: () => ipcRenderer.invoke('get-profile-name'),
+
   // Credentials management
   getCredentials: () => ipcRenderer.invoke('get-credentials'),
   saveCredentials: (credentials) => ipcRenderer.invoke('save-credentials', credentials),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -97,6 +97,7 @@ const elements = {
     refreshInterval: document.getElementById('refreshInterval'),
     orgSelector: document.getElementById('orgSelector'),
     orgSelectorCol: document.getElementById('orgSelectorCol'),
+    titleBarLabel: document.getElementById('titleBarLabel'),
 
     updateBanner: document.getElementById('updateBanner'),
     updateBannerText: document.getElementById('updateBannerText'),
@@ -170,6 +171,12 @@ async function handleOrgChange() {
 // Initialize
 async function init() {
     setupEventListeners();
+
+    const profileName = await window.electronAPI.getProfileName();
+    if (profileName && elements.titleBarLabel) {
+        elements.titleBarLabel.textContent = `Claude Usage — ${profileName}`;
+    }
+
     credentials = await window.electronAPI.getCredentials();
 
     // Apply saved theme and load thresholds immediately

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -24,7 +24,7 @@
             <div class="title-bar" id="titleBar">
                 <div class="title">
                     <img src="../../assets/logo.png" alt="Logo" class="app-logo">
-                    <span>Claude Usage</span>
+                    <span id="titleBarLabel">Claude Usage</span>
                 </div>
                 <div class="controls">
                     <button class="control-btn settings-btn" id="settingsBtn" title="Settings">⚙️</button>


### PR DESCRIPTION
## What this does

When running multiple `--profile=<name>` instances side by side (e.g. one per Claude account), every window and tray icon showed the same generic "Claude Usage" title and "Weekly Usage"/"Session Usage" tooltips — there was no way to tell at a glance which window belonged to which account.

This surfaces the profile name (already resolved in `main.js` from the `--profile` flag) in two places:
- The in-window title bar text, e.g. `Claude Usage — work`
- Both tray tooltips, e.g. `Weekly Usage — work` (and the dynamic `work — Weekly: 45%` tooltip shown after the first refresh)

Default, single-account usage (no `--profile` flag) is unchanged — the title bar and tooltips fall back to their existing unlabeled text.

Note: `develop` already has a related but distinct fix for multi-profile instances — scoping the Windows `AppUserModelID` per profile (commit `1cc9bde`, by @Hackpig1974) so taskbar buttons don't cluster together. That solves OS-level taskbar grouping; this PR solves the separate problem that the visible title bar and tray tooltip text still don't say which profile you're looking at.

## Changes
- `main.js`: expose the already-resolved profile name via a new `get-profile-name` IPC handler, and append it to the tray tooltip strings (both the static ones set at tray creation and the dynamic ones set on every usage refresh).
- `preload.js`: expose `getProfileName()` to the renderer.
- `src/renderer/index.html`: give the title-bar `<span>` an id so it can be updated.
- `src/renderer/app.js`: on init, read the profile name and apply it to the title-bar label.

## Testing
- Platform tested: Windows 11
- Verified: launching with no `--profile` flag leaves the title bar and tray tooltips unchanged; launching with `--profile=<name>` shows the name in the title bar, and (with "show tray stats" enabled in settings) in both tray tooltips
- Confirmed multiple profiles running side by side show distinct, correct labels

## Screenshots
<img width="361" height="144" alt="Screenshot 2026-09-04 182144" src="https://github.com/user-attachments/assets/6d240284-21d8-43e0-9587-07b97f09e1ff" />
<img width="695" height="184" alt="Screenshot 2026-09-04 182156" src="https://github.com/user-attachments/assets/da32f4f6-ae55-4208-ab6f-aab4b2e09636" />


## Related issues
None filed; this follows up on the existing `--profile` multi-account feature.
